### PR TITLE
feat(feed): add Build Type and AI tool filters

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -2,7 +2,11 @@ import { Suspense } from 'react';
 
 import { BuildCardSkeleton } from '@/components/feed/build-card-skeleton';
 import { BuildFeed } from '@/components/feed/build-feed';
+import { FeedFilters } from '@/components/feed/feed-filters';
+import { BUILD_TYPE_LABELS } from '@/lib/constants/builds';
+import { getAiTools } from '@/lib/queries/ai-tools';
 import { getBuilds } from '@/lib/queries/builds';
+import type { BuildType, FeedFilters as FeedFiltersType } from '@/types';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -10,6 +14,46 @@ import { getBuilds } from '@/lib/queries/builds';
 
 /** Number of skeleton cards shown while the feed is loading. */
 const SKELETON_COUNT = 6;
+
+/** URL search param key for build type filters. */
+const BUILD_TYPE_PARAM = 'buildType';
+
+/** URL search param key for AI tool filters. */
+const AI_TOOL_PARAM = 'aiTool';
+
+/** Set of valid build type values for validation. */
+const VALID_BUILD_TYPES = new Set<string>(Object.keys(BUILD_TYPE_LABELS));
+
+// ---------------------------------------------------------------------------
+// Search param parsing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a comma-separated `buildType` param into valid BuildType values.
+ * Invalid values are silently dropped.
+ */
+function parseBuildTypes(raw: string | undefined): BuildType[] {
+  if (!raw) {
+    return [];
+  }
+
+  return raw
+    .split(',')
+    .filter((value): value is BuildType => VALID_BUILD_TYPES.has(value));
+}
+
+/**
+ * Parses a comma-separated `aiTool` param into an array of IDs.
+ * Returns the raw split — server-side validation happens in the query
+ * (non-matching IDs simply return no results).
+ */
+function parseAiToolIds(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+
+  return raw.split(',').filter(Boolean);
+}
 
 // ---------------------------------------------------------------------------
 // Feed (async, Suspense-ready)
@@ -19,15 +63,21 @@ const SKELETON_COUNT = 6;
  * Async server component that fetches and renders the build feed.
  * Wrapped in a Suspense boundary by the parent page so Next.js can
  * stream the skeleton fallback while data loads.
+ *
+ * Accepts optional filters that are forwarded to `getBuilds()`.
  */
-async function Feed() {
-  const { data: builds, error } = await getBuilds();
+async function Feed({ filters }: { filters?: FeedFiltersType }) {
+  const hasActiveFilters =
+    (filters?.buildTypes?.length ?? 0) > 0 ||
+    (filters?.aiToolIds?.length ?? 0) > 0;
+
+  const { data: builds, error } = await getBuilds(filters);
 
   if (error) {
     throw error;
   }
 
-  return <BuildFeed builds={builds} />;
+  return <BuildFeed builds={builds} hasActiveFilters={hasActiveFilters} />;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,20 +99,71 @@ function FeedSkeleton() {
 // ---------------------------------------------------------------------------
 
 /**
- * Public home page that displays the build feed.
+ * Public home page that displays the build feed with filter controls.
  *
  * Auth note: This page is accessible to both authenticated and anonymous
  * users. The `builds` table has a public SELECT RLS policy, so the feed
  * query works without authentication. The `(main)` layout provides shared
  * navigation but does not enforce auth.
+ *
+ * Filters are read from URL search params and applied server-side:
+ * - `?buildType=app,feature` — comma-separated build types
+ * - `?aiTool=uuid1,uuid2` — comma-separated AI tool IDs
  */
-export default function HomePage() {
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const resolvedParams = await searchParams;
+
+  // Parse filter values from URL search params.
+  // Values can be string | string[] | undefined — we only handle strings.
+  const rawBuildType =
+    typeof resolvedParams[BUILD_TYPE_PARAM] === 'string'
+      ? resolvedParams[BUILD_TYPE_PARAM]
+      : undefined;
+  const rawAiTool =
+    typeof resolvedParams[AI_TOOL_PARAM] === 'string'
+      ? resolvedParams[AI_TOOL_PARAM]
+      : undefined;
+
+  const buildTypes = parseBuildTypes(rawBuildType);
+  const aiToolIds = parseAiToolIds(rawAiTool);
+
+  // Build the filters object. Only include non-empty arrays.
+  const filters: FeedFiltersType | undefined =
+    buildTypes.length > 0 || aiToolIds.length > 0
+      ? {
+          ...(buildTypes.length > 0 && { buildTypes }),
+          ...(aiToolIds.length > 0 && { aiToolIds }),
+        }
+      : undefined;
+
+  // Fetch AI tools for the filter controls (server-side).
+  const { data: aiTools } = await getAiTools();
+
+  // Serialize search params into a stable key so changing filters
+  // triggers a new Suspense boundary and re-shows the skeleton.
+  const suspenseKey = [
+    buildTypes.sort().join(','),
+    aiToolIds.sort().join(','),
+  ].join('|');
+
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold">Builds</h1>
-      <Suspense fallback={<FeedSkeleton />}>
-        <Feed />
+
+      {/* FeedFilters uses useSearchParams() so it needs its own Suspense boundary */}
+      <Suspense fallback={null}>
+        <FeedFilters aiTools={aiTools ?? []} />
       </Suspense>
+
+      <div className="mt-6">
+        <Suspense key={suspenseKey} fallback={<FeedSkeleton />}>
+          <Feed filters={filters} />
+        </Suspense>
+      </div>
     </div>
   );
 }

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -3,7 +3,11 @@ import { Suspense } from 'react';
 import { BuildCardSkeleton } from '@/components/feed/build-card-skeleton';
 import { BuildFeed } from '@/components/feed/build-feed';
 import { FeedFilters } from '@/components/feed/feed-filters';
-import { BUILD_TYPE_LABELS } from '@/lib/constants/builds';
+import {
+  AI_TOOL_PARAM,
+  BUILD_TYPE_LABELS,
+  BUILD_TYPE_PARAM,
+} from '@/lib/constants/builds';
 import { getAiTools } from '@/lib/queries/ai-tools';
 import { getBuilds } from '@/lib/queries/builds';
 import type { BuildType, FeedFilters as FeedFiltersType } from '@/types';
@@ -14,12 +18,6 @@ import type { BuildType, FeedFilters as FeedFiltersType } from '@/types';
 
 /** Number of skeleton cards shown while the feed is loading. */
 const SKELETON_COUNT = 6;
-
-/** URL search param key for build type filters. */
-const BUILD_TYPE_PARAM = 'buildType';
-
-/** URL search param key for AI tool filters. */
-const AI_TOOL_PARAM = 'aiTool';
 
 /** Set of valid build type values for validation. */
 const VALID_BUILD_TYPES = new Set<string>(Object.keys(BUILD_TYPE_LABELS));
@@ -141,13 +139,17 @@ export default async function HomePage({
       : undefined;
 
   // Fetch AI tools for the filter controls (server-side).
-  const { data: aiTools } = await getAiTools();
+  const { data: aiTools, error: aiToolsError } = await getAiTools();
+
+  if (aiToolsError) {
+    throw aiToolsError;
+  }
 
   // Serialize search params into a stable key so changing filters
   // triggers a new Suspense boundary and re-shows the skeleton.
   const suspenseKey = [
-    buildTypes.sort().join(','),
-    aiToolIds.sort().join(','),
+    [...buildTypes].sort().join(','),
+    [...aiToolIds].sort().join(','),
   ].join('|');
 
   return (

--- a/components/feed/build-feed.tsx
+++ b/components/feed/build-feed.tsx
@@ -12,6 +12,8 @@ import { BuildCard } from './build-card';
 
 type BuildFeedProps = {
   builds: BuildWithDetails[];
+  /** Whether the feed is being filtered. Affects the empty state message. */
+  hasActiveFilters?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -23,9 +25,26 @@ type BuildFeedProps = {
  * there are no builds to display.
  *
  * Grid layout: 1 column on mobile, 2 columns at `sm`, 3 columns at `lg`.
+ *
+ * When `hasActiveFilters` is true and there are no results, it shows a
+ * "No builds match your filters" message with a link to clear filters.
  */
-export function BuildFeed({ builds }: BuildFeedProps) {
+export function BuildFeed({
+  builds,
+  hasActiveFilters = false,
+}: BuildFeedProps) {
   if (builds.length === 0) {
+    if (hasActiveFilters) {
+      return (
+        <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
+          <p className="text-muted-foreground">No builds match your filters.</p>
+          <Button asChild variant="outline">
+            <Link href={Routes.HOME}>Clear filters</Link>
+          </Button>
+        </div>
+      );
+    }
+
     return (
       <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
         <p className="text-muted-foreground">

--- a/components/feed/feed-filters.tsx
+++ b/components/feed/feed-filters.tsx
@@ -19,19 +19,17 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
-import { BUILD_TYPE_LABELS } from '@/lib/constants/builds';
+import {
+  AI_TOOL_PARAM,
+  BUILD_TYPE_LABELS,
+  BUILD_TYPE_PARAM,
+} from '@/lib/constants/builds';
 import { cn } from '@/lib/utils';
 import type { AiTool, BuildType } from '@/types';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/** URL search param key for build type filters. */
-const BUILD_TYPE_PARAM = 'buildType';
-
-/** URL search param key for AI tool filters. */
-const AI_TOOL_PARAM = 'aiTool';
 
 /** All build type keys in display order. */
 const BUILD_TYPES = Object.keys(BUILD_TYPE_LABELS) as BuildType[];

--- a/components/feed/feed-filters.tsx
+++ b/components/feed/feed-filters.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import { CheckIcon, ChevronsUpDownIcon, XIcon } from 'lucide-react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useState } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { BUILD_TYPE_LABELS } from '@/lib/constants/builds';
+import { cn } from '@/lib/utils';
+import type { AiTool, BuildType } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** URL search param key for build type filters. */
+const BUILD_TYPE_PARAM = 'buildType';
+
+/** URL search param key for AI tool filters. */
+const AI_TOOL_PARAM = 'aiTool';
+
+/** All build type keys in display order. */
+const BUILD_TYPES = Object.keys(BUILD_TYPE_LABELS) as BuildType[];
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface FeedFiltersProps {
+  /** Available AI tools, passed from the server page component. */
+  aiTools: AiTool[];
+}
+
+// ---------------------------------------------------------------------------
+// FeedFilters
+// ---------------------------------------------------------------------------
+
+/**
+ * Client component that renders filter controls for the home feed.
+ *
+ * - Build Type toggle buttons for all 5 types
+ * - AI Tool multi-select using Popover + Command
+ * - Active filter badges with individual dismiss buttons
+ * - "Clear all" button when any filter is active
+ *
+ * Filter state is stored in URL search params so the server page
+ * component can read them and pass to `getBuilds()`.
+ */
+export function FeedFilters({ aiTools }: FeedFiltersProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [aiToolPopoverOpen, setAiToolPopoverOpen] = useState(false);
+
+  // -------------------------------------------------------------------------
+  // Read current filter state from URL
+  // -------------------------------------------------------------------------
+
+  const activeBuildTypes = parseBuildTypes(searchParams.get(BUILD_TYPE_PARAM));
+  const activeAiToolIds = parseAiToolIds(
+    searchParams.get(AI_TOOL_PARAM),
+    aiTools
+  );
+
+  const hasActiveFilters =
+    activeBuildTypes.length > 0 || activeAiToolIds.length > 0;
+
+  // -------------------------------------------------------------------------
+  // URL update helper
+  // -------------------------------------------------------------------------
+
+  const updateUrl = useCallback(
+    (buildTypes: BuildType[], aiToolIds: string[]) => {
+      const params = new URLSearchParams();
+
+      if (buildTypes.length > 0) {
+        params.set(BUILD_TYPE_PARAM, buildTypes.join(','));
+      }
+
+      if (aiToolIds.length > 0) {
+        params.set(AI_TOOL_PARAM, aiToolIds.join(','));
+      }
+
+      const queryString = params.toString();
+      const url = queryString ? `${pathname}?${queryString}` : pathname;
+
+      router.replace(url, { scroll: false });
+    },
+    [pathname, router]
+  );
+
+  // -------------------------------------------------------------------------
+  // Build Type toggle handlers
+  // -------------------------------------------------------------------------
+
+  function toggleBuildType(type: BuildType) {
+    const next = activeBuildTypes.includes(type)
+      ? activeBuildTypes.filter((t) => t !== type)
+      : [...activeBuildTypes, type];
+
+    updateUrl(next, activeAiToolIds);
+  }
+
+  function removeBuildType(type: BuildType) {
+    updateUrl(
+      activeBuildTypes.filter((t) => t !== type),
+      activeAiToolIds
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // AI Tool toggle handlers
+  // -------------------------------------------------------------------------
+
+  function toggleAiTool(toolId: string) {
+    const next = activeAiToolIds.includes(toolId)
+      ? activeAiToolIds.filter((id) => id !== toolId)
+      : [...activeAiToolIds, toolId];
+
+    updateUrl(activeBuildTypes, next);
+  }
+
+  function removeAiTool(toolId: string) {
+    updateUrl(
+      activeBuildTypes,
+      activeAiToolIds.filter((id) => id !== toolId)
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Clear all filters
+  // -------------------------------------------------------------------------
+
+  function clearAll() {
+    updateUrl([], []);
+  }
+
+  // -------------------------------------------------------------------------
+  // Derived data for AI Tool display
+  // -------------------------------------------------------------------------
+
+  const selectedAiTools = aiTools.filter((tool) =>
+    activeAiToolIds.includes(tool.id)
+  );
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  return (
+    <div className="space-y-3">
+      {/* Filter controls row */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Build Type toggles */}
+        <div className="flex flex-wrap gap-1.5">
+          {BUILD_TYPES.map((type) => {
+            const isActive = activeBuildTypes.includes(type);
+
+            return (
+              <Button
+                key={type}
+                variant={isActive ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => toggleBuildType(type)}
+                aria-pressed={isActive}
+              >
+                {BUILD_TYPE_LABELS[type]}
+              </Button>
+            );
+          })}
+        </div>
+
+        {/* AI Tool multi-select */}
+        <Popover open={aiToolPopoverOpen} onOpenChange={setAiToolPopoverOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              role="combobox"
+              aria-expanded={aiToolPopoverOpen}
+              className={cn(
+                'justify-between',
+                activeAiToolIds.length === 0 && 'text-muted-foreground'
+              )}
+            >
+              {activeAiToolIds.length > 0
+                ? `${activeAiToolIds.length} AI tool${activeAiToolIds.length === 1 ? '' : 's'}`
+                : 'AI Tools'}
+              <ChevronsUpDownIcon className="opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-56 p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Search AI tools..." />
+              <CommandList>
+                <CommandEmpty>No AI tools found.</CommandEmpty>
+                <CommandGroup>
+                  {aiTools.map((tool) => {
+                    const isSelected = activeAiToolIds.includes(tool.id);
+
+                    return (
+                      <CommandItem
+                        key={tool.id}
+                        value={tool.name}
+                        onSelect={() => toggleAiTool(tool.id)}
+                      >
+                        <div
+                          className={cn(
+                            'flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary',
+                            isSelected
+                              ? 'bg-primary text-primary-foreground'
+                              : 'opacity-50 [&_svg]:invisible'
+                          )}
+                        >
+                          <CheckIcon className="size-3" />
+                        </div>
+                        {tool.name}
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+
+        {/* Clear all button */}
+        {hasActiveFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearAll}
+            className="text-muted-foreground"
+          >
+            Clear all
+          </Button>
+        )}
+      </div>
+
+      {/* Active filter badges */}
+      {hasActiveFilters && (
+        <div className="flex flex-wrap gap-1.5">
+          {activeBuildTypes.map((type) => (
+            <Badge key={type} variant="secondary">
+              {BUILD_TYPE_LABELS[type]}
+              <button
+                type="button"
+                className="ml-1 rounded-full outline-none hover:text-foreground"
+                onClick={() => removeBuildType(type)}
+                aria-label={`Remove ${BUILD_TYPE_LABELS[type]} filter`}
+              >
+                <XIcon className="size-3" />
+              </button>
+            </Badge>
+          ))}
+          {selectedAiTools.map((tool) => (
+            <Badge key={tool.id} variant="secondary">
+              {tool.name}
+              <button
+                type="button"
+                className="ml-1 rounded-full outline-none hover:text-foreground"
+                onClick={() => removeAiTool(tool.id)}
+                aria-label={`Remove ${tool.name} filter`}
+              >
+                <XIcon className="size-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// URL param parsing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a comma-separated `buildType` param value into valid BuildType values.
+ * Invalid values are silently dropped.
+ */
+function parseBuildTypes(raw: string | null): BuildType[] {
+  if (!raw) {
+    return [];
+  }
+
+  const validTypes = new Set<string>(BUILD_TYPES);
+
+  return raw
+    .split(',')
+    .filter((value): value is BuildType => validTypes.has(value));
+}
+
+/**
+ * Parses a comma-separated `aiTool` param value into valid AI tool IDs.
+ * IDs not found in the available tools list are silently dropped.
+ */
+function parseAiToolIds(
+  raw: string | null,
+  availableTools: AiTool[]
+): string[] {
+  if (!raw) {
+    return [];
+  }
+
+  const validIds = new Set(availableTools.map((tool) => tool.id));
+
+  return raw.split(',').filter((id) => validIds.has(id));
+}

--- a/lib/constants/builds.ts
+++ b/lib/constants/builds.ts
@@ -13,3 +13,9 @@ export const BUILD_TYPE_LABELS: Record<BuildType, string> = {
   automation: 'Automation',
   experiment: 'Experiment',
 };
+
+/** URL search param key for build type filters. */
+export const BUILD_TYPE_PARAM = 'buildType';
+
+/** URL search param key for AI tool filters. */
+export const AI_TOOL_PARAM = 'aiTool';

--- a/lib/queries/builds.ts
+++ b/lib/queries/builds.ts
@@ -93,13 +93,10 @@ export async function getBuilds(filters?: FeedFilters) {
       return { data: null, error };
     }
 
-    const builds: BuildWithDetails[] = (data ?? []).map(
-      (build) =>
-        ({
-          ...build,
-          upvote_count: build.upvotes[0]?.count ?? 0,
-        }) as BuildWithDetails
-    );
+    const builds: BuildWithDetails[] = (data ?? []).map((build) => {
+      const { filter_ai: _filter_ai, ...rest } = build;
+      return { ...rest, upvote_count: build.upvotes[0]?.count ?? 0 };
+    });
 
     return { data: builds, error: null };
   }

--- a/lib/queries/builds.ts
+++ b/lib/queries/builds.ts
@@ -118,13 +118,10 @@ export async function getBuilds(filters?: FeedFilters) {
     return { data: null, error };
   }
 
-  const builds: BuildWithDetails[] = (data ?? []).map(
-    (build) =>
-      ({
-        ...build,
-        upvote_count: build.upvotes[0]?.count ?? 0,
-      }) as BuildWithDetails
-  );
+  const builds: BuildWithDetails[] = (data ?? []).map((build) => {
+    const { upvotes, ...rest } = build;
+    return { ...rest, upvote_count: upvotes[0]?.count ?? 0 };
+  });
 
   return { data: builds, error: null };
 }

--- a/lib/queries/builds.ts
+++ b/lib/queries/builds.ts
@@ -1,7 +1,12 @@
 import 'server-only';
 
 import { createClient } from '@/lib/supabase/server';
-import type { BuildType, BuildUpdate, BuildWithDetails } from '@/types';
+import type {
+  BuildType,
+  BuildUpdate,
+  BuildWithDetails,
+  FeedFilters,
+} from '@/types';
 
 /**
  * Shared select string for fetching builds with all related data.
@@ -21,6 +26,26 @@ const BUILD_WITH_DETAILS_SELECT = `
   upvotes:upvotes(count)
 ` as const;
 
+/**
+ * Select string that includes an additional `!inner` join on `build_ai_tools`
+ * for filtering. The alias `filter_ai` restricts parent rows to those with
+ * at least one matching AI tool, without corrupting the display join
+ * (`ai_tools`) that fetches the full list of AI tools per build.
+ */
+const BUILD_WITH_DETAILS_AND_AI_FILTER_SELECT = `
+  *,
+  profile:profiles!builds_user_id_fkey(*),
+  screenshots:build_screenshots(*),
+  ai_tools:build_ai_tools(
+    ...ai_tools(*)
+  ),
+  tech_stack_tags:build_tech_stack_tags(
+    ...tech_stack_tags(*)
+  ),
+  upvotes:upvotes(count),
+  filter_ai:build_ai_tools!inner(ai_tool_id)
+` as const;
+
 /** Maximum number of builds returned per page. */
 const BUILDS_PAGE_SIZE = 20;
 
@@ -30,15 +55,67 @@ const BUILDS_PAGE_SIZE = 20;
  * (via junction table), and upvote count.
  *
  * Results are ordered by newest first and limited to {@link BUILDS_PAGE_SIZE}.
+ *
+ * Optional filters narrow the results server-side:
+ * - `buildTypes` — only builds whose `build_type` is in the list
+ * - `aiToolIds` — only builds linked to at least one of the given AI tools
+ *
+ * Omitting a filter (or passing an empty array) returns all builds for
+ * that dimension, so the unfiltered call path is unchanged.
  */
-export async function getBuilds() {
+export async function getBuilds(filters?: FeedFilters) {
   const supabase = await createClient();
 
-  const { data, error } = await supabase
+  const activeBuildTypes = filters?.buildTypes?.length
+    ? filters.buildTypes
+    : null;
+  const activeAiToolIds = filters?.aiToolIds?.length ? filters.aiToolIds : null;
+
+  // When filtering by AI tool we use a separate code path that includes
+  // an `!inner` join alias (`filter_ai`). This keeps both select strings
+  // as compile-time literal types so Supabase's PostgREST type inference
+  // works correctly in each branch.
+  if (activeAiToolIds) {
+    let query = supabase
+      .from('builds')
+      .select(BUILD_WITH_DETAILS_AND_AI_FILTER_SELECT)
+      .in('filter_ai.ai_tool_id', activeAiToolIds)
+      .order('created_at', { ascending: false })
+      .range(0, BUILDS_PAGE_SIZE - 1);
+
+    if (activeBuildTypes) {
+      query = query.in('build_type', activeBuildTypes);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      return { data: null, error };
+    }
+
+    const builds: BuildWithDetails[] = (data ?? []).map(
+      (build) =>
+        ({
+          ...build,
+          upvote_count: build.upvotes[0]?.count ?? 0,
+        }) as BuildWithDetails
+    );
+
+    return { data: builds, error: null };
+  }
+
+  // No AI tool filter — use the standard select without the extra join.
+  let query = supabase
     .from('builds')
     .select(BUILD_WITH_DETAILS_SELECT)
     .order('created_at', { ascending: false })
     .range(0, BUILDS_PAGE_SIZE - 1);
+
+  if (activeBuildTypes) {
+    query = query.in('build_type', activeBuildTypes);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     return { data: null, error };

--- a/types/index.ts
+++ b/types/index.ts
@@ -45,6 +45,21 @@ export type CommentUpdate = TablesUpdate<'comments'>;
 export type BuildType = Enums<'build_type'>;
 
 // ---------------------------------------------------------------------------
+// Filter types — used for parameterized queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional filters for the feed query. All fields are optional —
+ * omitting a field (or passing an empty array) disables that filter.
+ */
+export interface FeedFilters {
+  /** Restrict results to these build types (e.g. "app", "feature"). */
+  buildTypes?: BuildType[];
+  /** Restrict results to builds that use at least one of these AI tools. */
+  aiToolIds?: string[];
+}
+
+// ---------------------------------------------------------------------------
 // Composite types — used when fetching builds with joined relations
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `FeedFilters` client component with Build Type toggle buttons (all 5 types) and AI Tool multi-select (Popover + Command)
- Extend `getBuilds` query with optional `buildTypes` and `aiToolIds` filter params — server-side filtering via Supabase with `!inner` join alias for AI tools
- Wire filters into home feed page — parses URL search params, passes to `getBuilds`, wraps `FeedFilters` in Suspense, keys feed Suspense on filter state for skeleton re-render on change
- Filters are combinable and stored in URL for shareable views (`?buildType=app,feature&aiTool=uuid1,uuid2`)
- Active filter badges with individual dismiss buttons and "Clear all"
- Updated empty state in `BuildFeed` to distinguish "No builds match your filters" (with "Clear filters" link) from "No builds yet"

## GitHub Issue

Closes #22

## Test Plan

- [ ] Build Type toggle buttons appear above the feed
- [ ] Clicking a type filters the feed to that type only
- [ ] Multiple types can be selected (combinable)
- [ ] AI Tool dropdown shows all predefined tools
- [ ] Selecting an AI tool filters the feed to builds using that tool
- [ ] Build Type + AI Tool filters combine correctly (e.g. "Apps built with Claude")
- [ ] Active filter badges appear below the controls with ✕ dismiss buttons
- [ ] "Clear all" button resets all filters
- [ ] URL updates to reflect active filters (e.g. `?buildType=app&aiTool=<uuid>`)
- [ ] Navigating to a filtered URL pre-selects the correct filters
- [ ] Empty state shows "No builds match your filters" when filters return no results
- [ ] Feed loading skeleton re-appears when filters change

🤖 Generated with Claude Code