### PR TITLE
feat(profile): create builder profile page

### DIFF
--- a/app/(main)/builds/[id]/edit/page.tsx
+++ b/app/(main)/builds/[id]/edit/page.tsx
@@ -6,6 +6,7 @@ import { buildRoute } from '@/lib/constants/routes';
 import { getAiTools } from '@/lib/queries/ai-tools';
 import { getBuildById } from '@/lib/queries/builds';
 import { getTechStackTags } from '@/lib/queries/tech-stack-tags';
+import { isUuid } from '@/lib/utils';
 
 type EditBuildPageProps = {
   params: Promise<{ id: string }>;
@@ -14,16 +15,28 @@ type EditBuildPageProps = {
 export default async function EditBuildPage({ params }: EditBuildPageProps) {
   const { id } = await params;
 
-  const [user, { data: build }, { data: aiTools }, { data: techStackTags }] =
-    await Promise.all([
-      requireUser(),
-      getBuildById(id),
-      getAiTools(),
-      getTechStackTags(),
-    ]);
+  if (!isUuid(id)) {
+    notFound();
+  }
+
+  const [
+    user,
+    { data: build },
+    { data: aiTools, error: aiToolsError },
+    { data: techStackTags, error: techStackTagsError },
+  ] = await Promise.all([
+    requireUser(),
+    getBuildById(id),
+    getAiTools(),
+    getTechStackTags(),
+  ]);
 
   if (!build) {
     notFound();
+  }
+
+  if (aiToolsError || techStackTagsError) {
+    throw new Error('Failed to load form data');
   }
 
   // Builds are public, so redirecting non-owners to the view page is

--- a/app/(main)/builds/[id]/page.tsx
+++ b/app/(main)/builds/[id]/page.tsx
@@ -10,6 +10,7 @@ import { getUser } from '@/lib/auth';
 import { BUILD_TYPE_LABELS } from '@/lib/constants/builds';
 import { profileRoute } from '@/lib/constants/routes';
 import { getBuildById } from '@/lib/queries/builds';
+import { isUuid } from '@/lib/utils';
 
 type BuildDetailPageProps = {
   params: Promise<{ id: string }>;
@@ -19,6 +20,11 @@ export default async function BuildDetailPage({
   params,
 }: BuildDetailPageProps) {
   const { id } = await params;
+
+  if (!isUuid(id)) {
+    notFound();
+  }
+
   const [{ data: build }, user] = await Promise.all([
     getBuildById(id),
     getUser(),

--- a/app/(main)/profile/[id]/not-found.tsx
+++ b/app/(main)/profile/[id]/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+import { Routes } from '@/lib/constants/routes';
+
+export default function ProfileNotFound() {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 px-4 text-center">
+      <h1 className="text-2xl font-bold">Profile not found</h1>
+      <p className="text-muted-foreground">
+        This builder profile doesn&apos;t exist or may have been removed.
+      </p>
+      <Link
+        href={Routes.HOME}
+        className="text-sm font-medium text-primary hover:underline"
+      >
+        Back to home
+      </Link>
+    </div>
+  );
+}

--- a/app/(main)/profile/[id]/page.tsx
+++ b/app/(main)/profile/[id]/page.tsx
@@ -4,6 +4,7 @@ import { ProfileBuildList } from '@/components/profile/profile-build-list';
 import { ProfileHeader } from '@/components/profile/profile-header';
 import { getBuildsForUser } from '@/lib/queries/builds';
 import { getProfileById } from '@/lib/queries/profiles';
+import { isUuid } from '@/lib/utils';
 
 type PublicProfilePageProps = {
   params: Promise<{ id: string }>;
@@ -14,23 +15,26 @@ export default async function PublicProfilePage({
 }: PublicProfilePageProps) {
   const { id } = await params;
 
-  const [profileResult, buildsResult] = await Promise.all([
-    getProfileById(id),
-    getBuildsForUser(id).catch(() => ({ data: null, error: null })),
-  ]);
-
-  if (!profileResult.data) {
+  if (!isUuid(id)) {
     notFound();
   }
 
-  const profile = profileResult.data;
-  const builds = buildsResult.data ?? [];
+  const [{ data: profile }, { data: builds, error: buildsError }] =
+    await Promise.all([getProfileById(id), getBuildsForUser(id)]);
+
+  if (!profile) {
+    notFound();
+  }
+
+  if (buildsError) {
+    throw buildsError;
+  }
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-8">
       <div className="space-y-10">
         <ProfileHeader profile={profile} />
-        <ProfileBuildList builds={builds} />
+        <ProfileBuildList builds={builds ?? []} />
       </div>
     </main>
   );

--- a/app/(main)/profile/[id]/page.tsx
+++ b/app/(main)/profile/[id]/page.tsx
@@ -1,3 +1,37 @@
-export default function PublicProfilePage() {
-  return <div>Public Profile</div>;
+import { notFound } from 'next/navigation';
+
+import { ProfileBuildList } from '@/components/profile/profile-build-list';
+import { ProfileHeader } from '@/components/profile/profile-header';
+import { getBuildsForUser } from '@/lib/queries/builds';
+import { getProfileById } from '@/lib/queries/profiles';
+
+type PublicProfilePageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function PublicProfilePage({
+  params,
+}: PublicProfilePageProps) {
+  const { id } = await params;
+
+  const [profileResult, buildsResult] = await Promise.all([
+    getProfileById(id),
+    getBuildsForUser(id).catch(() => ({ data: null, error: null })),
+  ]);
+
+  if (!profileResult.data) {
+    notFound();
+  }
+
+  const profile = profileResult.data;
+  const builds = buildsResult.data ?? [];
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <div className="space-y-10">
+        <ProfileHeader profile={profile} />
+        <ProfileBuildList builds={builds} />
+      </div>
+    </main>
+  );
 }

--- a/components/profile/profile-build-list.tsx
+++ b/components/profile/profile-build-list.tsx
@@ -1,0 +1,45 @@
+import { BuildCard } from '@/components/feed/build-card';
+import { Badge } from '@/components/ui/badge';
+import type { BuildWithDetails } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+type ProfileBuildListProps = {
+  builds: BuildWithDetails[];
+};
+
+// ---------------------------------------------------------------------------
+// ProfileBuildList
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders a list of builds for a user's profile page. Shows a heading with
+ * a count badge and a responsive grid of build cards, or an empty state
+ * when the user has no builds.
+ */
+export function ProfileBuildList({ builds }: ProfileBuildListProps) {
+  return (
+    <section>
+      {/* Heading with count badge */}
+      <div className="flex items-center gap-2">
+        <h2 className="text-xl font-semibold tracking-tight">Builds</h2>
+        <Badge variant="secondary">{builds.length}</Badge>
+      </div>
+
+      {/* Build grid or empty state */}
+      {builds.length === 0 ? (
+        <p className="py-12 text-center text-muted-foreground">
+          No builds yet.
+        </p>
+      ) : (
+        <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {builds.map((build) => (
+            <BuildCard key={build.id} build={build} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/profile/profile-header.tsx
+++ b/components/profile/profile-header.tsx
@@ -1,7 +1,25 @@
-import { Github, Globe, Linkedin, Twitter } from 'lucide-react';
+import { Github, Globe, Linkedin } from 'lucide-react';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import type { Profile } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+/** Inline X (formerly Twitter) logo — lucide-react removed brand icons. */
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.737-8.835L1.254 2.25H8.08l4.259 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z" />
+    </svg>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Props
@@ -21,7 +39,7 @@ type ProfileHeaderProps = {
  */
 const SOCIAL_LINKS = [
   { key: 'github_url', icon: Github, label: 'GitHub' },
-  { key: 'twitter_url', icon: Twitter, label: 'X (Twitter)' },
+  { key: 'twitter_url', icon: XIcon, label: 'X (Twitter)' },
   { key: 'linkedin_url', icon: Linkedin, label: 'LinkedIn' },
   { key: 'website_url', icon: Globe, label: 'Website' },
 ] as const;

--- a/components/profile/profile-header.tsx
+++ b/components/profile/profile-header.tsx
@@ -1,0 +1,102 @@
+import { Github, Globe, Linkedin, Twitter } from 'lucide-react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import type { Profile } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+type ProfileHeaderProps = {
+  profile: Profile;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Social link configuration — maps a profile field to an icon and label.
+ * Each entry is only rendered when the corresponding URL is non-null.
+ */
+const SOCIAL_LINKS = [
+  { key: 'github_url', icon: Github, label: 'GitHub' },
+  { key: 'twitter_url', icon: Twitter, label: 'X (Twitter)' },
+  { key: 'linkedin_url', icon: Linkedin, label: 'LinkedIn' },
+  { key: 'website_url', icon: Globe, label: 'Website' },
+] as const;
+
+// ---------------------------------------------------------------------------
+// ProfileHeader
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders the profile header section: avatar, display name, bio, join date,
+ * and social links. All social/display fields are nullable — fields are
+ * hidden rather than showing empty placeholders.
+ */
+export function ProfileHeader({ profile }: ProfileHeaderProps) {
+  const displayName = profile.display_name ?? 'Anonymous';
+
+  const joinDate = new Date(profile.created_at).toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+
+  return (
+    <div className="flex flex-col items-center gap-4 text-center">
+      {/* Avatar — size-20 override via className */}
+      <Avatar className="size-20">
+        {profile.avatar_url && (
+          <AvatarImage src={profile.avatar_url} alt={displayName} />
+        )}
+        <AvatarFallback className="text-2xl">
+          {displayName.charAt(0).toUpperCase()}
+        </AvatarFallback>
+      </Avatar>
+
+      {/* Display name */}
+      <h1 className="text-2xl font-bold tracking-tight">{displayName}</h1>
+
+      {/* Bio — only shown when present */}
+      {profile.bio && (
+        <p className="max-w-md text-muted-foreground">{profile.bio}</p>
+      )}
+
+      {/* Join date */}
+      <p className="text-sm text-muted-foreground">Joined {joinDate}</p>
+
+      {/* Social links — only rendered when at least one URL is present */}
+      <SocialLinks profile={profile} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SocialLinks (internal)
+// ---------------------------------------------------------------------------
+
+function SocialLinks({ profile }: { profile: Profile }) {
+  const links = SOCIAL_LINKS.filter((link) => profile[link.key] !== null);
+
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      {links.map(({ key, icon: Icon, label }) => (
+        <a
+          key={key}
+          href={profile[key]!}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-muted-foreground transition-colors hover:text-foreground"
+          aria-label={label}
+        >
+          <Icon className="size-5" />
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/lib/queries/builds.ts
+++ b/lib/queries/builds.ts
@@ -127,6 +127,34 @@ export async function getBuilds(filters?: FeedFilters) {
 }
 
 /**
+ * Fetches all builds for a specific user, including the author profile,
+ * screenshots, AI tools, tech stack tags, and upvote count.
+ *
+ * Results are ordered by newest first (no pagination — profile pages
+ * show the complete list).
+ */
+export async function getBuildsForUser(userId: string) {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('builds')
+    .select(BUILD_WITH_DETAILS_SELECT)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  const builds: BuildWithDetails[] = (data ?? []).map((build) => {
+    const { upvotes, ...rest } = build;
+    return { ...rest, upvote_count: upvotes[0]?.count ?? 0 };
+  });
+
+  return { data: builds, error: null };
+}
+
+/**
  * Fetches a single build by ID with all related data (profile,
  * screenshots, AI tools, tech stack tags, and upvote count).
  *

--- a/lib/queries/profiles.ts
+++ b/lib/queries/profiles.ts
@@ -3,13 +3,29 @@ import 'server-only';
 import { createClient } from '@/lib/supabase/server';
 import type { ProfileUpdate } from '@/types';
 
+// Fetch-by-ID contract: throws on real DB errors, returns { data: null } when not found.
+// Callers can safely treat !data as "not found" and call notFound().
 /**
  * Fetches a single profile by its ID.
+ *
+ * @throws {PostgrestError} When a database error occurs (not when a row is missing — missing rows return null data).
  */
 export async function getProfileById(id: string) {
   const supabase = await createClient();
 
-  return supabase.from('profiles').select('*').eq('id', id).single();
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+
+  // maybeSingle() returns null data (no error) when the row doesn't exist,
+  // and only errors on real DB failures — throw to bubble up to error.tsx.
+  if (error) {
+    throw error;
+  }
+
+  return { data };
 }
 
 /**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string): boolean {
+  return UUID_RE.test(value);
+}


### PR DESCRIPTION
## Summary

- Add `getBuildsForUser(userId)` query to `lib/queries/builds.ts` — fetches all builds for a user, newest first, reusing `BUILD_WITH_DETAILS_SELECT`
- Add `app/(main)/profile/[id]/not-found.tsx` — 404 page for non-existent profiles
- Add `components/profile/profile-header.tsx` — avatar, display name, bio, join date, and social links (GitHub, Twitter/X, LinkedIn, website)
- Add `components/profile/profile-build-list.tsx` — responsive grid of `BuildCard`s with count badge and empty state
- Implement `app/(main)/profile/[id]/page.tsx` — parallel data fetching, `notFound()` guard, renders header + build list

## GitHub Issue

Closes #23

## Test Plan

- [ ] Visit `/profile/{id}` for an existing user — display name, avatar, bio, join date, and social links render correctly
- [ ] Nullable fields (bio, social links) are hidden when not set — no empty placeholders
- [ ] Builds section shows the user's builds in newest-first order with correct count badge
- [ ] Empty state ("No builds yet.") renders for users with no builds
- [ ] Visit `/profile/nonexistent-id` — renders the "Profile not found" 404 page with "Back to home" link

🤖 Generated with Claude Code