### PR TITLE
feat(profile): add edit profile functionality

### DIFF
--- a/app/(main)/profile/[id]/page.tsx
+++ b/app/(main)/profile/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 
 import { ProfileBuildList } from '@/components/profile/profile-build-list';
 import { ProfileHeader } from '@/components/profile/profile-header';
+import { getUser } from '@/lib/auth';
 import { getBuildsForUser } from '@/lib/queries/builds';
 import { getProfileById } from '@/lib/queries/profiles';
 import { isUuid } from '@/lib/utils';
@@ -19,8 +20,8 @@ export default async function PublicProfilePage({
     notFound();
   }
 
-  const [{ data: profile }, { data: builds, error: buildsError }] =
-    await Promise.all([getProfileById(id), getBuildsForUser(id)]);
+  const [user, { data: profile }, { data: builds, error: buildsError }] =
+    await Promise.all([getUser(), getProfileById(id), getBuildsForUser(id)]);
 
   if (!profile) {
     notFound();
@@ -30,10 +31,12 @@ export default async function PublicProfilePage({
     throw buildsError;
   }
 
+  const isOwner = user?.id === profile.id;
+
   return (
     <main className="mx-auto max-w-5xl px-4 py-8">
       <div className="space-y-10">
-        <ProfileHeader profile={profile} />
+        <ProfileHeader profile={profile} isOwner={isOwner} />
         <ProfileBuildList builds={builds ?? []} />
       </div>
     </main>

--- a/app/(main)/profile/settings/page.tsx
+++ b/app/(main)/profile/settings/page.tsx
@@ -1,3 +1,23 @@
-export default function ProfileSettingsPage() {
-  return <div>Profile Settings</div>;
+import { notFound } from 'next/navigation';
+
+import { ProfileSettingsForm } from '@/components/profile/profile-settings-form';
+import { requireUser } from '@/lib/auth';
+import { getProfileById } from '@/lib/queries/profiles';
+
+export default async function ProfileSettingsPage() {
+  const user = await requireUser();
+  const { data: profile } = await getProfileById(user.id);
+
+  if (!profile) {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold tracking-tight">
+        Profile Settings
+      </h1>
+      <ProfileSettingsForm initialData={profile} />
+    </div>
+  );
 }

--- a/app/actions/profile.ts
+++ b/app/actions/profile.ts
@@ -8,12 +8,19 @@ import { createClient } from '@/lib/supabase/server';
 import { profileFormSchema } from '@/lib/validations/profile';
 
 /**
- * Builds the expected URL prefix for avatars uploaded by a given user.
+ * Returns the public URL prefix for the avatars bucket.
  * Any avatar_url that starts with this prefix was uploaded by us (not
  * an OAuth provider like Google or GitHub).
  */
+function avatarBucketPrefix(): string {
+  return `${clientEnv.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${AVATAR_BUCKET_NAME}/`;
+}
+
+/**
+ * Builds the expected URL prefix for avatars uploaded by a given user.
+ */
 function avatarStoragePrefix(userId: string): string {
-  return `${clientEnv.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${AVATAR_BUCKET_NAME}/${userId}/`;
+  return `${avatarBucketPrefix()}${userId}/`;
 }
 
 /**
@@ -33,9 +40,7 @@ function extractAvatarStoragePath(url: string, userId: string): string | null {
   }
 
   // Slice from the bucket name boundary so the result includes `{userId}/{filename}`.
-  const bucketPrefix = `${clientEnv.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${AVATAR_BUCKET_NAME}/`;
-
-  return url.slice(bucketPrefix.length);
+  return url.slice(avatarBucketPrefix().length);
 }
 
 /**
@@ -48,9 +53,12 @@ function extractAvatarStoragePath(url: string, userId: string): string | null {
  * 4. If the profile has an existing avatar from our storage, delete it
  * 5. Call updateProfile with the validated data
  *
- * Returns `{ error: string }` on failure or `{ success: true }` on success.
+ * Returns a discriminated union: `{ success: true }` on success,
+ * or `{ success: false; error: string }` on failure.
  */
-export async function updateProfileAction(formData: FormData) {
+export async function updateProfileAction(
+  formData: FormData
+): Promise<{ success: true } | { success: false; error: string }> {
   const user = await requireUser();
 
   // Parse form fields into a plain object for Zod validation
@@ -66,7 +74,7 @@ export async function updateProfileAction(formData: FormData) {
   const result = profileFormSchema.safeParse(rawData);
 
   if (!result.success) {
-    return { error: 'Invalid form data' };
+    return { success: false as const, error: 'Invalid form data' };
   }
 
   // avatar_url is handled outside the Zod schema (like screenshots in
@@ -79,13 +87,12 @@ export async function updateProfileAction(formData: FormData) {
   // the authenticated user's folder. External URLs (e.g. GitHub/Google OAuth
   // avatars) are allowed through — we don't control their origin.
   if (avatarUrlString) {
-    const bucketPrefix = `${clientEnv.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${AVATAR_BUCKET_NAME}/`;
-    const isOurStorage = avatarUrlString.startsWith(bucketPrefix);
+    const isOurStorage = avatarUrlString.startsWith(avatarBucketPrefix());
 
     if (isOurStorage) {
       const allowedPrefix = avatarStoragePrefix(user.id);
       if (!avatarUrlString.startsWith(allowedPrefix)) {
-        return { error: 'Invalid avatar URL' };
+        return { success: false as const, error: 'Invalid avatar URL' };
       }
     }
   }
@@ -107,7 +114,7 @@ export async function updateProfileAction(formData: FormData) {
     const { data: currentProfile } = await getProfileById(user.id);
 
     if (!currentProfile) {
-      return { error: 'Profile not found' };
+      return { success: false as const, error: 'Profile not found' };
     }
 
     // Delete the old avatar from storage if:
@@ -140,12 +147,15 @@ export async function updateProfileAction(formData: FormData) {
     const { error } = await updateProfile(user.id, profileData);
 
     if (error) {
-      return { error: error.message ?? 'Failed to update profile' };
+      return {
+        success: false as const,
+        error: error.message ?? 'Failed to update profile',
+      };
     }
 
     return { success: true as const };
   } catch (error) {
     console.error('updateProfileAction failed:', error);
-    return { error: 'An unexpected error occurred' };
+    return { success: false as const, error: 'An unexpected error occurred' };
   }
 }

--- a/app/actions/profile.ts
+++ b/app/actions/profile.ts
@@ -18,16 +18,24 @@ function avatarStoragePrefix(userId: string): string {
 
 /**
  * Extracts the storage path from a full avatar URL.
- * Returns null if the URL does not belong to our avatars bucket.
+ * Returns null if the URL does not belong to the authenticated user's
+ * avatar folder.
+ *
+ * The returned path is relative to the bucket root (e.g. `{userId}/{filename}`)
+ * because `supabase.storage.from(bucket).remove()` expects bucket-relative paths.
  */
 function extractAvatarStoragePath(url: string, userId: string): string | null {
-  const prefix = avatarStoragePrefix(userId);
+  // Ownership check — the URL must belong to this user's folder.
+  const ownershipPrefix = avatarStoragePrefix(userId);
 
-  if (!url.startsWith(prefix)) {
+  if (!url.startsWith(ownershipPrefix)) {
     return null;
   }
 
-  return url.slice(prefix.length);
+  // Slice from the bucket name boundary so the result includes `{userId}/{filename}`.
+  const bucketPrefix = `${clientEnv.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${AVATAR_BUCKET_NAME}/`;
+
+  return url.slice(bucketPrefix.length);
 }
 
 /**

--- a/app/actions/profile.ts
+++ b/app/actions/profile.ts
@@ -75,13 +75,18 @@ export async function updateProfileAction(formData: FormData) {
   const avatarUrlString =
     typeof avatarUrl === 'string' && avatarUrl.length > 0 ? avatarUrl : null;
 
-  // Validate that the avatar URL belongs to the authenticated user's
-  // storage folder. This prevents injection of arbitrary external URLs.
+  // If the avatar URL points to our own storage, validate it belongs to
+  // the authenticated user's folder. External URLs (e.g. GitHub/Google OAuth
+  // avatars) are allowed through — we don't control their origin.
   if (avatarUrlString) {
-    const allowedPrefix = avatarStoragePrefix(user.id);
+    const bucketPrefix = `${clientEnv.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${AVATAR_BUCKET_NAME}/`;
+    const isOurStorage = avatarUrlString.startsWith(bucketPrefix);
 
-    if (!avatarUrlString.startsWith(allowedPrefix)) {
-      return { error: 'Invalid avatar URL' };
+    if (isOurStorage) {
+      const allowedPrefix = avatarStoragePrefix(user.id);
+      if (!avatarUrlString.startsWith(allowedPrefix)) {
+        return { error: 'Invalid avatar URL' };
+      }
     }
   }
 

--- a/app/actions/profile.ts
+++ b/app/actions/profile.ts
@@ -1,0 +1,138 @@
+'use server';
+
+import { requireUser } from '@/lib/auth';
+import { AVATAR_BUCKET_NAME } from '@/lib/constants/storage';
+import { clientEnv } from '@/lib/env.client';
+import { getProfileById, updateProfile } from '@/lib/queries/profiles';
+import { createClient } from '@/lib/supabase/server';
+import { profileFormSchema } from '@/lib/validations/profile';
+
+/**
+ * Builds the expected URL prefix for avatars uploaded by a given user.
+ * Any avatar_url that starts with this prefix was uploaded by us (not
+ * an OAuth provider like Google or GitHub).
+ */
+function avatarStoragePrefix(userId: string): string {
+  return `${clientEnv.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${AVATAR_BUCKET_NAME}/${userId}/`;
+}
+
+/**
+ * Extracts the storage path from a full avatar URL.
+ * Returns null if the URL does not belong to our avatars bucket.
+ */
+function extractAvatarStoragePath(url: string, userId: string): string | null {
+  const prefix = avatarStoragePrefix(userId);
+
+  if (!url.startsWith(prefix)) {
+    return null;
+  }
+
+  return url.slice(prefix.length);
+}
+
+/**
+ * Server action that updates the authenticated user's profile.
+ *
+ * Steps:
+ * 1. Authenticate the user (redirects to login if not signed in)
+ * 2. Validate form data against the Zod schema
+ * 3. If an avatar_url is provided, validate it belongs to this user
+ * 4. If the profile has an existing avatar from our storage, delete it
+ * 5. Call updateProfile with the validated data
+ *
+ * Returns `{ error: string }` on failure or `{ success: true }` on success.
+ */
+export async function updateProfileAction(formData: FormData) {
+  const user = await requireUser();
+
+  // Parse form fields into a plain object for Zod validation
+  const rawData = {
+    display_name: formData.get('display_name') ?? '',
+    bio: formData.get('bio') ?? '',
+    github_url: formData.get('github_url') ?? '',
+    twitter_url: formData.get('twitter_url') ?? '',
+    linkedin_url: formData.get('linkedin_url') ?? '',
+    website_url: formData.get('website_url') ?? '',
+  };
+
+  const result = profileFormSchema.safeParse(rawData);
+
+  if (!result.success) {
+    return { error: 'Invalid form data' };
+  }
+
+  // avatar_url is handled outside the Zod schema (like screenshots in
+  // the build form). It's passed as a separate FormData field.
+  const avatarUrl = formData.get('avatar_url');
+  const avatarUrlString =
+    typeof avatarUrl === 'string' && avatarUrl.length > 0 ? avatarUrl : null;
+
+  // Validate that the avatar URL belongs to the authenticated user's
+  // storage folder. This prevents injection of arbitrary external URLs.
+  if (avatarUrlString) {
+    const allowedPrefix = avatarStoragePrefix(user.id);
+
+    if (!avatarUrlString.startsWith(allowedPrefix)) {
+      return { error: 'Invalid avatar URL' };
+    }
+  }
+
+  // Convert empty strings to null for clean database storage
+  const profileData = {
+    display_name: result.data.display_name || null,
+    bio: result.data.bio || null,
+    github_url: result.data.github_url || null,
+    twitter_url: result.data.twitter_url || null,
+    linkedin_url: result.data.linkedin_url || null,
+    website_url: result.data.website_url || null,
+    avatar_url: avatarUrlString,
+  };
+
+  try {
+    // Fetch the current profile to check for an existing avatar that
+    // needs cleanup from storage.
+    const { data: currentProfile } = await getProfileById(user.id);
+
+    if (!currentProfile) {
+      return { error: 'Profile not found' };
+    }
+
+    // Delete the old avatar from storage if:
+    // 1. There is an existing avatar_url on the profile
+    // 2. It came from our avatars bucket (not an OAuth provider avatar)
+    // 3. It's different from the new avatar_url (user changed their avatar)
+    const oldAvatarUrl = currentProfile.avatar_url;
+
+    if (oldAvatarUrl && oldAvatarUrl !== avatarUrlString) {
+      const storagePath = extractAvatarStoragePath(oldAvatarUrl, user.id);
+
+      if (storagePath) {
+        const supabase = await createClient();
+        const { error: storageError } = await supabase.storage
+          .from(AVATAR_BUCKET_NAME)
+          .remove([storagePath]);
+
+        if (storageError) {
+          // Best-effort cleanup — log but don't fail the action since
+          // the profile update hasn't happened yet and we still want
+          // to proceed with saving the new data.
+          console.error(
+            'Failed to delete old avatar from storage:',
+            storageError
+          );
+        }
+      }
+    }
+
+    const { error } = await updateProfile(user.id, profileData);
+
+    if (error) {
+      return { error: error.message ?? 'Failed to update profile' };
+    }
+
+    return { success: true as const };
+  } catch (error) {
+    console.error('updateProfileAction failed:', error);
+    return { error: 'An unexpected error occurred' };
+  }
+}

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 
 import { getUser } from '@/lib/auth';
 import { MimeExtension } from '@/lib/constants/mime-types';
-import { BUCKET_NAME } from '@/lib/constants/storage';
 import { createClient } from '@/lib/supabase/server';
 import { uploadRequestSchema } from '@/lib/validations/upload';
 
@@ -31,7 +30,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const { contentType } = result.data;
+  const { contentType, bucket } = result.data;
 
   const supabase = await createClient();
 
@@ -40,7 +39,7 @@ export async function POST(request: Request) {
   const path = `${user.id}/${fileName}`;
 
   const { data, error } = await supabase.storage
-    .from(BUCKET_NAME)
+    .from(bucket)
     .createSignedUploadUrl(path);
 
   if (error) {

--- a/components/profile/avatar-upload.tsx
+++ b/components/profile/avatar-upload.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { CameraIcon, Loader2Icon, UserIcon } from 'lucide-react';
+import Image from 'next/image';
+import { useCallback, useRef, useState } from 'react';
+
+import { MimeType } from '@/lib/constants/mime-types';
+import { AVATAR_BUCKET_NAME } from '@/lib/constants/storage';
+import { createClient } from '@/lib/supabase/client';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024; // 2 MB
+const ACCEPTED_MIME_TYPES = Object.values(MimeType);
+const ACCEPT_STRING = ACCEPTED_MIME_TYPES.join(',');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type UploadApiResponse = {
+  token: string;
+  path: string;
+};
+
+type AvatarUploadProps = {
+  /** Current avatar URL, or null if no avatar is set. */
+  value: string | null;
+  /** Called with the new public URL after upload, or null to clear. */
+  onChange: (url: string | null) => void;
+};
+
+// ---------------------------------------------------------------------------
+// AvatarUpload
+// ---------------------------------------------------------------------------
+
+export function AvatarUpload({ value, onChange }: AvatarUploadProps) {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // -------------------------------------------------------------------------
+  // Upload a single file: get signed URL -> upload to storage -> get public URL
+  // -------------------------------------------------------------------------
+
+  const uploadFile = useCallback(async (file: File): Promise<string> => {
+    const supabase = createClient();
+
+    // 1. Request a signed upload URL from our API
+    const response = await fetch('/api/upload', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contentType: file.type,
+        bucket: AVATAR_BUCKET_NAME,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      throw new Error(body?.error ?? 'Failed to get upload URL');
+    }
+
+    const { token, path } = (await response.json()) as UploadApiResponse;
+
+    // 2. Upload the file to Supabase Storage using the signed URL
+    const { error: uploadError } = await supabase.storage
+      .from(AVATAR_BUCKET_NAME)
+      .uploadToSignedUrl(path, token, file, {
+        contentType: file.type,
+      });
+
+    if (uploadError) {
+      throw new Error(uploadError.message);
+    }
+
+    // 3. Get the public URL for the uploaded file
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from(AVATAR_BUCKET_NAME).getPublicUrl(path);
+
+    return publicUrl;
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Handle file selection from the input
+  // -------------------------------------------------------------------------
+
+  async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    setError(null);
+
+    // Validate MIME type
+    if (!ACCEPTED_MIME_TYPES.includes(file.type as MimeType)) {
+      setError('Only PNG, JPEG, GIF, and WebP images are allowed');
+      resetInput();
+      return;
+    }
+
+    // Validate file size
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setError('Image must be under 2 MB');
+      resetInput();
+      return;
+    }
+
+    setUploading(true);
+
+    try {
+      const publicUrl = await uploadFile(file);
+      onChange(publicUrl);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to upload avatar');
+    } finally {
+      setUploading(false);
+      resetInput();
+    }
+  }
+
+  function resetInput() {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {/* Circular avatar preview with upload overlay */}
+      <button
+        type="button"
+        disabled={uploading}
+        onClick={() => fileInputRef.current?.click()}
+        className="group relative size-24 overflow-hidden rounded-full border-2 border-muted bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label="Upload avatar"
+      >
+        {/* Current avatar or placeholder */}
+        {value ? (
+          <Image
+            src={value}
+            alt="Avatar preview"
+            fill
+            className="object-cover"
+            sizes="96px"
+          />
+        ) : (
+          <div className="flex size-full items-center justify-center">
+            <UserIcon className="size-10 text-muted-foreground" />
+          </div>
+        )}
+
+        {/* Hover/uploading overlay */}
+        <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100 group-disabled:opacity-100">
+          {uploading ? (
+            <Loader2Icon className="size-6 animate-spin text-white" />
+          ) : (
+            <CameraIcon className="size-6 text-white" />
+          )}
+        </div>
+      </button>
+
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPT_STRING}
+        onChange={handleFileChange}
+        className="hidden"
+        aria-label="Select avatar image"
+      />
+
+      <p className="text-xs text-muted-foreground">
+        Click to upload. Max 2 MB.
+      </p>
+
+      {/* Error message */}
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/profile/profile-header.tsx
+++ b/components/profile/profile-header.tsx
@@ -1,6 +1,9 @@
-import { Github, Globe, Linkedin } from 'lucide-react';
+import { Github, Globe, Linkedin, PencilIcon } from 'lucide-react';
+import Link from 'next/link';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Routes } from '@/lib/constants/routes';
 import type { Profile } from '@/types';
 
 // ---------------------------------------------------------------------------
@@ -27,6 +30,7 @@ function XIcon({ className }: { className?: string }) {
 
 type ProfileHeaderProps = {
   profile: Profile;
+  isOwner?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -53,7 +57,10 @@ const SOCIAL_LINKS = [
  * and social links. All social/display fields are nullable — fields are
  * hidden rather than showing empty placeholders.
  */
-export function ProfileHeader({ profile }: ProfileHeaderProps) {
+export function ProfileHeader({
+  profile,
+  isOwner = false,
+}: ProfileHeaderProps) {
   const displayName = profile.display_name ?? 'Anonymous';
 
   const joinDate = new Date(profile.created_at).toLocaleDateString('en-US', {
@@ -86,6 +93,16 @@ export function ProfileHeader({ profile }: ProfileHeaderProps) {
 
       {/* Social links — only rendered when at least one URL is present */}
       <SocialLinks profile={profile} />
+
+      {/* Edit Profile — only shown to the profile owner */}
+      {isOwner && (
+        <Button variant="outline" size="sm" asChild>
+          <Link href={Routes.PROFILE_SETTINGS}>
+            <PencilIcon />
+            Edit Profile
+          </Link>
+        </Button>
+      )}
     </div>
   );
 }

--- a/components/profile/profile-settings-form.tsx
+++ b/components/profile/profile-settings-form.tsx
@@ -79,7 +79,7 @@ export function ProfileSettingsForm({ initialData }: ProfileSettingsFormProps) {
 
       const result = await updateProfileAction(formData);
 
-      if ('error' in result) {
+      if (!result.success) {
         toast.error(result.error);
         return;
       }

--- a/components/profile/profile-settings-form.tsx
+++ b/components/profile/profile-settings-form.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2Icon } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -19,6 +20,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { profileRoute } from '@/lib/constants/routes';
 import {
   type ProfileFormData,
   profileFormSchema,
@@ -39,6 +41,7 @@ type ProfileSettingsFormProps = {
 // ---------------------------------------------------------------------------
 
 export function ProfileSettingsForm({ initialData }: ProfileSettingsFormProps) {
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
   // Avatar URL is managed outside the Zod schema (same pattern as
@@ -82,6 +85,7 @@ export function ProfileSettingsForm({ initialData }: ProfileSettingsFormProps) {
       }
 
       toast.success('Profile updated!');
+      router.push(profileRoute(initialData.id));
     });
   }
 

--- a/components/profile/profile-settings-form.tsx
+++ b/components/profile/profile-settings-form.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2Icon } from 'lucide-react';
+import { useState, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+
+import { updateProfileAction } from '@/app/actions/profile';
+import { AvatarUpload } from '@/components/profile/avatar-upload';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  type ProfileFormData,
+  profileFormSchema,
+} from '@/lib/validations/profile';
+import type { Profile } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+type ProfileSettingsFormProps = {
+  /** Current profile data used to pre-populate the form. */
+  initialData: Profile;
+};
+
+// ---------------------------------------------------------------------------
+// ProfileSettingsForm
+// ---------------------------------------------------------------------------
+
+export function ProfileSettingsForm({ initialData }: ProfileSettingsFormProps) {
+  const [isPending, startTransition] = useTransition();
+
+  // Avatar URL is managed outside the Zod schema (same pattern as
+  // screenshots in BuildForm). It's passed as a separate FormData field.
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(
+    initialData.avatar_url
+  );
+
+  const form = useForm<ProfileFormData>({
+    resolver: zodResolver(profileFormSchema),
+    defaultValues: {
+      display_name: initialData.display_name ?? '',
+      bio: initialData.bio ?? '',
+      github_url: initialData.github_url ?? '',
+      twitter_url: initialData.twitter_url ?? '',
+      linkedin_url: initialData.linkedin_url ?? '',
+      website_url: initialData.website_url ?? '',
+    },
+  });
+
+  function onSubmit(data: ProfileFormData) {
+    startTransition(async () => {
+      const formData = new FormData();
+
+      formData.append('display_name', data.display_name ?? '');
+      formData.append('bio', data.bio ?? '');
+      formData.append('github_url', data.github_url ?? '');
+      formData.append('twitter_url', data.twitter_url ?? '');
+      formData.append('linkedin_url', data.linkedin_url ?? '');
+      formData.append('website_url', data.website_url ?? '');
+
+      if (avatarUrl) {
+        formData.append('avatar_url', avatarUrl);
+      }
+
+      const result = await updateProfileAction(formData);
+
+      if ('error' in result) {
+        toast.error(result.error);
+        return;
+      }
+
+      toast.success('Profile updated!');
+    });
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {/* Avatar */}
+        <div>
+          <AvatarUpload value={avatarUrl} onChange={setAvatarUrl} />
+        </div>
+
+        {/* Display Name */}
+        <FormField
+          control={form.control}
+          name="display_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Display Name</FormLabel>
+              <FormControl>
+                <Input placeholder="Your name" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Bio */}
+        <FormField
+          control={form.control}
+          name="bio"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Bio</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="A short bio about yourself..."
+                  className="min-h-20"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* GitHub URL */}
+        <FormField
+          control={form.control}
+          name="github_url"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                GitHub URL{' '}
+                <span className="text-muted-foreground">(optional)</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type="url"
+                  placeholder="https://github.com/username"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Twitter URL */}
+        <FormField
+          control={form.control}
+          name="twitter_url"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Twitter URL{' '}
+                <span className="text-muted-foreground">(optional)</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type="url"
+                  placeholder="https://twitter.com/username"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* LinkedIn URL */}
+        <FormField
+          control={form.control}
+          name="linkedin_url"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                LinkedIn URL{' '}
+                <span className="text-muted-foreground">(optional)</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type="url"
+                  placeholder="https://linkedin.com/in/username"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Website URL */}
+        <FormField
+          control={form.control}
+          name="website_url"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Website URL{' '}
+                <span className="text-muted-foreground">(optional)</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type="url"
+                  placeholder="https://yourwebsite.com"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Submit */}
+        <Button type="submit" className="w-full" disabled={isPending}>
+          {isPending && <Loader2Icon className="animate-spin" />}
+          {isPending ? 'Saving...' : 'Save Changes'}
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/lib/constants/routes.ts
+++ b/lib/constants/routes.ts
@@ -4,6 +4,7 @@ export const Routes = {
   SIGNUP: '/signup',
   AUTH_CALLBACK: '/auth/callback',
   BUILD_NEW: '/builds/new',
+  PROFILE_SETTINGS: '/profile/settings',
 } as const;
 
 /** Returns the path for a specific build's detail page. */

--- a/lib/constants/storage.ts
+++ b/lib/constants/storage.ts
@@ -1,1 +1,2 @@
 export const BUCKET_NAME = 'build-screenshots';
+export const AVATAR_BUCKET_NAME = 'avatars';

--- a/lib/validations/upload.ts
+++ b/lib/validations/upload.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { MimeType } from '@/lib/constants/mime-types';
+import { AVATAR_BUCKET_NAME, BUCKET_NAME } from '@/lib/constants/storage';
 
 // ---------------------------------------------------------------------------
 // Upload request — used when requesting a signed URL for file upload
@@ -8,10 +9,21 @@ import { MimeType } from '@/lib/constants/mime-types';
 
 const allowedMimeTypes = Object.values(MimeType) as [MimeType, ...MimeType[]];
 
+/**
+ * Allowlisted storage buckets. Only these buckets can be targeted by the
+ * upload API. Defaults to 'build-screenshots' for backwards compatibility.
+ */
+const allowedBuckets = [BUCKET_NAME, AVATAR_BUCKET_NAME] as const;
+
 export const uploadRequestSchema = z.object({
   contentType: z.enum(allowedMimeTypes, {
     error: 'File must be an image (png, jpeg, gif, or webp)',
   }),
+  bucket: z
+    .enum(allowedBuckets, {
+      error: `Bucket must be one of: ${allowedBuckets.join(', ')}`,
+    })
+    .default(BUCKET_NAME),
 });
 
 export type UploadRequestData = z.infer<typeof uploadRequestSchema>;

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,11 @@ const nextConfig: NextConfig = {
         port: '54321',
         pathname: '/storage/v1/object/public/**',
       },
+      // GitHub OAuth avatars
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+      },
     ],
   },
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -27,6 +27,11 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'avatars.githubusercontent.com',
       },
+      // Google OAuth avatars
+      {
+        protocol: 'https',
+        hostname: '**.googleusercontent.com',
+      },
     ],
   },
 };

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -117,6 +117,12 @@ public = true
 file_size_limit = "5MiB"
 allowed_mime_types = ["image/png", "image/jpeg", "image/webp", "image/gif"]
 
+# Local dev bucket for user avatars
+[storage.buckets.avatars]
+public = true
+file_size_limit = "5MiB"
+allowed_mime_types = ["image/png", "image/jpeg", "image/webp", "image/gif"]
+
 # Allow connections via S3 compatible clients
 [storage.s3_protocol]
 enabled = true

--- a/supabase/migrations/20260316000001_avatars_storage_setup.sql
+++ b/supabase/migrations/20260316000001_avatars_storage_setup.sql
@@ -1,0 +1,40 @@
+-- =============================================================================
+-- Storage: avatars bucket and RLS policies
+-- =============================================================================
+
+-- Create the avatars bucket (public read)
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('avatars', 'avatars', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Public read access
+CREATE POLICY "Public read access for avatars"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'avatars');
+
+-- Authenticated users can upload to their own folder only ({user_id}/{filename})
+CREATE POLICY "Authenticated users can upload avatars"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = (select auth.uid()::text)
+  );
+
+-- Users can update their own files
+CREATE POLICY "Users can update own avatars"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND owner_id = (select auth.uid()::text)
+  );
+
+-- Users can delete their own files
+CREATE POLICY "Users can delete own avatars"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND owner_id = (select auth.uid()::text)
+  );

--- a/supabase/migrations/20260316000001_avatars_storage_setup.sql
+++ b/supabase/migrations/20260316000001_avatars_storage_setup.sql
@@ -3,8 +3,8 @@
 -- =============================================================================
 
 -- Create the avatars bucket (public read)
-INSERT INTO storage.buckets (id, name, public)
-VALUES ('avatars', 'avatars', true)
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('avatars', 'avatars', true, 5242880, ARRAY['image/png', 'image/jpeg', 'image/webp', 'image/gif'])
 ON CONFLICT (id) DO NOTHING;
 
 -- Public read access


### PR DESCRIPTION
## Summary

- Add profile settings page at `/profile/settings` allowing users to edit display name, bio, avatar, and social links
- Avatar upload to dedicated `avatars` Supabase Storage bucket with per-user folder RLS
- Extended `/api/upload` to accept an allowlisted `bucket` param (backwards compatible)
- Avatar URL validation: enforces storage-folder ownership for our bucket, allows OAuth provider avatars (GitHub/Google) through
- Redirects to profile page after successful save
- "Edit Profile" button on profile page visible only to the profile owner

## GitHub Issue

Closes #24

## Test Plan

- [ ] Visit your profile page — "Edit Profile" button is visible only when logged in as the owner
- [ ] Navigate to `/profile/settings` — redirects to login if unauthenticated
- [ ] Update display name, bio, and social URLs — changes are saved and reflected on profile page
- [ ] Upload a new avatar — circular preview updates, avatar saved to `avatars` bucket
- [ ] Save with default GitHub OAuth avatar — no "Invalid avatar URL" error
- [ ] Save profile — toast appears and page redirects to profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)