### PR TITLE
feat(layout): build global navigation and page layout

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,19 +1,19 @@
-import { SignOutButton } from '@/components/auth/sign-out-button';
+import { Navbar } from '@/components/layout/navbar';
+import { getUser } from '@/lib/auth';
+import { getProfileById } from '@/lib/queries/profiles';
 
-export default function MainLayout({
+export default async function MainLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const user = await getUser();
+  const profile = user ? (await getProfileById(user.id)).data : null;
+
   return (
     <div className="min-h-screen">
-      <header className="border-b">
-        <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
-          <span className="text-lg font-semibold">Bob the Builder</span>
-          <SignOutButton />
-        </div>
-      </header>
-      <main>{children}</main>
+      <Navbar user={user} profile={profile} />
+      <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
     </div>
   );
 }

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -8,7 +8,11 @@ export default async function MainLayout({
   children: React.ReactNode;
 }>) {
   const user = await getUser();
-  const profile = user ? (await getProfileById(user.id)).data : null;
+  const profile = user
+    ? await getProfileById(user.id)
+        .then((r) => r.data)
+        .catch(() => null)
+    : null;
 
   return (
     <div className="min-h-screen">

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -13,7 +13,7 @@ export default async function MainLayout({
   return (
     <div className="min-h-screen">
       <Navbar user={user} profile={profile} />
-      <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
+      <main>{children}</main>
     </div>
   );
 }

--- a/app/(main)/profile/[id]/page.tsx
+++ b/app/(main)/profile/[id]/page.tsx
@@ -34,11 +34,11 @@ export default async function PublicProfilePage({
   const isOwner = user?.id === profile.id;
 
   return (
-    <main className="mx-auto max-w-5xl px-4 py-8">
+    <div className="mx-auto max-w-5xl px-4 py-8">
       <div className="space-y-10">
         <ProfileHeader profile={profile} isOwner={isOwner} />
         <ProfileBuildList builds={builds ?? []} />
       </div>
-    </main>
+    </div>
   );
 }

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -1,0 +1,57 @@
+import type { User } from '@supabase/supabase-js';
+import { Plus } from 'lucide-react';
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/button';
+import { Routes } from '@/lib/constants/routes';
+import type { Profile } from '@/types';
+
+import { UserMenu } from './user-menu';
+
+interface NavbarProps {
+  user: User | null;
+  profile: Profile | null;
+}
+
+export function Navbar({ user, profile }: NavbarProps) {
+  return (
+    <nav className="border-b">
+      <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
+        <div className="flex items-center gap-6">
+          <Link href={Routes.HOME} className="text-lg font-semibold">
+            Bob the Builder
+          </Link>
+
+          <Link
+            href={Routes.FEED}
+            className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Feed
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button asChild size="sm">
+            <Link href={Routes.BUILD_NEW}>
+              <Plus data-icon="inline-start" />
+              Submit Build
+            </Link>
+          </Button>
+
+          {user ? (
+            <UserMenu profile={profile} />
+          ) : (
+            <>
+              <Button variant="ghost" size="sm" asChild>
+                <Link href={Routes.LOGIN}>Log in</Link>
+              </Button>
+              <Button size="sm" asChild>
+                <Link href={Routes.SIGNUP}>Sign up</Link>
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/components/layout/user-menu.tsx
+++ b/components/layout/user-menu.tsx
@@ -53,7 +53,10 @@ export function UserMenu({ profile }: UserMenuProps) {
 
       <DropdownMenuContent align="end" className="w-48">
         {profile?.display_name && (
-          <DropdownMenuLabel>{profile.display_name}</DropdownMenuLabel>
+          <>
+            <DropdownMenuLabel>{profile.display_name}</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+          </>
         )}
 
         <DropdownMenuGroup>

--- a/components/layout/user-menu.tsx
+++ b/components/layout/user-menu.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { LogOut, Settings, User } from 'lucide-react';
+import Link from 'next/link';
+import { useRef } from 'react';
+
+import { signOut } from '@/app/actions/auth';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { profileRoute, Routes } from '@/lib/constants/routes';
+import type { Profile } from '@/types';
+
+interface UserMenuProps {
+  profile: Profile | null;
+}
+
+function getAvatarFallback(profile: Profile | null): string {
+  if (!profile?.display_name) {
+    return 'U';
+  }
+  return profile.display_name.charAt(0).toUpperCase();
+}
+
+export function UserMenu({ profile }: UserMenuProps) {
+  const signOutFormRef = useRef<HTMLFormElement>(null);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="cursor-pointer rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          <Avatar>
+            {profile?.avatar_url && (
+              <AvatarImage
+                src={profile.avatar_url}
+                alt={profile.display_name ?? 'User avatar'}
+              />
+            )}
+            <AvatarFallback>{getAvatarFallback(profile)}</AvatarFallback>
+          </Avatar>
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" className="w-48">
+        {profile?.display_name && (
+          <DropdownMenuLabel>{profile.display_name}</DropdownMenuLabel>
+        )}
+
+        <DropdownMenuGroup>
+          {profile && (
+            <DropdownMenuItem asChild>
+              <Link href={profileRoute(profile.id)}>
+                <User />
+                Profile
+              </Link>
+            </DropdownMenuItem>
+          )}
+
+          <DropdownMenuItem asChild>
+            <Link href={Routes.PROFILE_SETTINGS}>
+              <Settings />
+              Settings
+            </Link>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuGroup>
+          <DropdownMenuItem
+            onSelect={() => signOutFormRef.current?.requestSubmit()}
+          >
+            <LogOut />
+            Sign out
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+
+        {/* Hidden form for the signOut server action */}
+        <form ref={signOutFormRef} action={signOut} className="hidden" />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/lib/constants/routes.ts
+++ b/lib/constants/routes.ts
@@ -1,5 +1,6 @@
 export const Routes = {
   HOME: '/',
+  FEED: '/',
   LOGIN: '/login',
   SIGNUP: '/signup',
   AUTH_CALLBACK: '/auth/callback',


### PR DESCRIPTION
## Summary

- Add global navbar (`components/layout/navbar.tsx`) — Server Component with logo, feed link, Submit Build CTA, and conditional auth controls
- Add avatar dropdown (`components/layout/user-menu.tsx`) — Client Component with profile link, settings link, and sign out
- Update `app/(main)/layout.tsx` to fetch user/profile server-side and render the Navbar
- Add `FEED` route constant to `lib/constants/routes.ts` as a semantic alias for the home/feed page
- Fix pre-existing nested `<main>` landmark in `app/(main)/profile/[id]/page.tsx`

## GitHub Issue

Closes #26

## Test Plan

- [ ] Logged-out: navbar shows logo, Feed link, Submit Build CTA, Log in + Sign up buttons
- [ ] Logged-in: navbar shows logo, Feed link, Submit Build CTA, avatar dropdown
- [ ] Avatar dropdown: profile link navigates to user profile, settings link navigates to settings, sign out logs user out
- [ ] All pages in `(main)` route group render with consistent navbar
- [ ] Page content spacing is unchanged (each page still owns its own container)

🤖 Generated with Claude Code