### PR TITLE
fix(navbar): remove redundant Feed link

### DIFF
--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -7,7 +7,6 @@ import { HardhatIcon } from '@/components/ui/icons';
 import { Routes } from '@/lib/constants/routes';
 import type { Profile } from '@/types';
 
-import { NavLink } from './nav-link';
 import { UserMenu } from './user-menu';
 
 interface NavbarProps {
@@ -34,10 +33,6 @@ export function Navbar({ user, profile }: NavbarProps) {
               </span>
             </div>
           </Link>
-
-          <NavLink href={Routes.FEED} activeOn={[Routes.HOME]} className="ml-4">
-            Feed
-          </NavLink>
         </div>
 
         {/* Right side actions */}


### PR DESCRIPTION
## Summary

- Removed the `Feed` NavLink from the navbar — the logo already links to `/` (the feed page), making it duplicate navigation
- Removed the now-unused `NavLink` import

## GitHub Issue

Closes #67

## Test Plan

- [ ] Navigate to the app and confirm the navbar only has the logo linking to `/`, with no separate "Feed" link
- [ ] Clicking the logo still navigates to the feed page

🤖 Generated with Claude Code