### PR TITLE
fix(ui): improve checkmark visibility in multi-select checkboxes

### DIFF
--- a/components/builds/build-form.tsx
+++ b/components/builds/build-form.tsx
@@ -418,11 +418,11 @@ function MultiSelectCombobox({
                         className={cn(
                           'flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary',
                           isSelected
-                            ? 'bg-primary text-primary-foreground'
+                            ? 'bg-primary text-white'
                             : 'opacity-50 [&_svg]:invisible'
                         )}
                       >
-                        <CheckIcon className="size-3" />
+                        <CheckIcon className="size-3 text-white stroke-[3]" />
                       </div>
                       {item.label}
                     </CommandItem>

--- a/components/builds/build-form.tsx
+++ b/components/builds/build-form.tsx
@@ -418,11 +418,11 @@ function MultiSelectCombobox({
                         className={cn(
                           'flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary',
                           isSelected
-                            ? 'bg-primary text-white'
+                            ? 'bg-primary text-primary-foreground'
                             : 'opacity-50 [&_svg]:invisible'
                         )}
                       >
-                        <CheckIcon className="size-3 text-white stroke-[3]" />
+                        <CheckIcon className="size-3 stroke-[3] text-primary-foreground" />
                       </div>
                       {item.label}
                     </CommandItem>

--- a/components/feed/feed-filters.tsx
+++ b/components/feed/feed-filters.tsx
@@ -221,11 +221,11 @@ export function FeedFilters({ aiTools }: FeedFiltersProps) {
                           className={cn(
                             'flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary',
                             isSelected
-                              ? 'bg-primary text-white'
+                              ? 'bg-primary text-primary-foreground'
                               : 'opacity-50 [&_svg]:invisible'
                           )}
                         >
-                          <CheckIcon className="size-3 text-white stroke-[3]" />
+                          <CheckIcon className="size-3 stroke-[3] text-primary-foreground" />
                         </div>
                         {tool.name}
                       </CommandItem>

--- a/components/feed/feed-filters.tsx
+++ b/components/feed/feed-filters.tsx
@@ -221,11 +221,11 @@ export function FeedFilters({ aiTools }: FeedFiltersProps) {
                           className={cn(
                             'flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary',
                             isSelected
-                              ? 'bg-primary text-primary-foreground'
+                              ? 'bg-primary text-white'
                               : 'opacity-50 [&_svg]:invisible'
                           )}
                         >
-                          <CheckIcon className="size-3" />
+                          <CheckIcon className="size-3 text-white stroke-[3]" />
                         </div>
                         {tool.name}
                       </CommandItem>


### PR DESCRIPTION
## Summary

- Changed checkmark color from `text-primary-foreground` to explicit `text-white` for better contrast on amber `bg-primary` background
- Increased `CheckIcon` stroke width from default `2` to `3` for a bolder, more visible checkmark
- Applied fix to both affected components: `feed-filters.tsx` and `build-form.tsx`

## GitHub Issue

Closes #68

## Test Plan

- [ ] Open Feed page → AI Tools filter dropdown → select items → verify checkmark is clearly visible
- [ ] Open New Build form → AI Tools multi-select → select items → verify checkmark is clearly visible
- [ ] Open New Build form → Tech Stack multi-select → select items → verify checkmark is clearly visible
- [ ] Verify dark mode checkmark still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)