### PR TITLE
refactor(ui): extract shared CommandCheckbox component

### DIFF
--- a/components/builds/build-form.tsx
+++ b/components/builds/build-form.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import {
-  CheckIcon,
-  ChevronsUpDownIcon,
-  Loader2Icon,
-  XIcon,
-} from 'lucide-react';
+import { ChevronsUpDownIcon, Loader2Icon, XIcon } from 'lucide-react';
 import { useTransition } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -26,6 +21,7 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command';
+import { CommandCheckbox } from '@/components/ui/command-checkbox';
 import {
   Form,
   FormControl,
@@ -414,16 +410,7 @@ function MultiSelectCombobox({
                       value={item.label}
                       onSelect={() => toggleItem(item.value)}
                     >
-                      <div
-                        className={cn(
-                          'flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary',
-                          isSelected
-                            ? 'bg-primary text-primary-foreground'
-                            : 'opacity-50 [&_svg]:invisible'
-                        )}
-                      >
-                        <CheckIcon className="size-3" />
-                      </div>
+                      <CommandCheckbox isSelected={isSelected} />
                       {item.label}
                     </CommandItem>
                   );

--- a/components/feed/feed-filters.tsx
+++ b/components/feed/feed-filters.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CheckIcon, ChevronsUpDownIcon, XIcon } from 'lucide-react';
+import { ChevronsUpDownIcon, XIcon } from 'lucide-react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useState } from 'react';
 
@@ -14,6 +14,7 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command';
+import { CommandCheckbox } from '@/components/ui/command-checkbox';
 import {
   Popover,
   PopoverContent,
@@ -217,16 +218,7 @@ export function FeedFilters({ aiTools }: FeedFiltersProps) {
                         value={tool.name}
                         onSelect={() => toggleAiTool(tool.id)}
                       >
-                        <div
-                          className={cn(
-                            'flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary',
-                            isSelected
-                              ? 'bg-primary text-primary-foreground'
-                              : 'opacity-50 [&_svg]:invisible'
-                          )}
-                        >
-                          <CheckIcon className="size-3" />
-                        </div>
+                        <CommandCheckbox isSelected={isSelected} />
                         {tool.name}
                       </CommandItem>
                     );

--- a/components/ui/command-checkbox.tsx
+++ b/components/ui/command-checkbox.tsx
@@ -1,0 +1,21 @@
+import { CheckIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+// text-primary-foreground on the CheckIcon is required — CommandItem applies
+// [&_svg:not([class*='text-'])]:text-muted-foreground to all descendant SVGs,
+// which overrides inherited color unless a text-* class is present on the icon.
+export function CommandCheckbox({ isSelected }: { isSelected: boolean }) {
+  return (
+    <div
+      className={cn(
+        'flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary',
+        isSelected
+          ? 'bg-primary text-primary-foreground'
+          : 'opacity-50 [&_svg]:invisible'
+      )}
+    >
+      <CheckIcon className="size-3 stroke-[3] text-primary-foreground" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Extracted a shared `CommandCheckbox` presentational component into `components/ui/command-checkbox.tsx`
- Replaced duplicated checkbox markup in `feed-filters.tsx` and `build-form.tsx` with the new component
- Includes the `stroke-[3]` fix for checkmark visibility from #68
- Added a comment explaining why `text-primary-foreground` on the `CheckIcon` is load-bearing (blocks `CommandItem`'s `[&_svg:not([class*='text-'])]:text-muted-foreground` selector)

## Why

This was raised during the PR #80 review by @INNOVATIVEGAMER. The checkbox workaround pattern (`text-primary-foreground` on the icon to override `CommandItem`'s SVG color selector) was duplicated across two files. Without a shared component and an explanatory comment, a future contributor could easily remove the "redundant-looking" class and reintroduce the visibility bug. Centralizing it in one place with one explanation prevents that.

## GitHub Issue

Closes #82

## Test Plan

- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify checkbox checkmarks are visible in the AI Tools filter dropdown on the feed page
- [ ] Verify checkbox checkmarks are visible in the multi-select comboboxes on the build form
- [ ] Verify no visual regression in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)