### PR TITLE
feat(feed): add pagination to build feed

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,15 +1,18 @@
+import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
 
 import { BuildCardSkeleton } from '@/components/feed/build-card-skeleton';
 import { BuildFeed } from '@/components/feed/build-feed';
 import { FeedFilters } from '@/components/feed/feed-filters';
+import { FeedPagination } from '@/components/feed/feed-pagination';
 import {
   AI_TOOL_PARAM,
   BUILD_TYPE_LABELS,
   BUILD_TYPE_PARAM,
+  PAGE_PARAM,
 } from '@/lib/constants/builds';
 import { getAiTools } from '@/lib/queries/ai-tools';
-import { getBuilds } from '@/lib/queries/builds';
+import { BUILDS_PAGE_SIZE, getBuilds } from '@/lib/queries/builds';
 import type { BuildType, FeedFilters as FeedFiltersType } from '@/types';
 
 // ---------------------------------------------------------------------------
@@ -53,6 +56,19 @@ function parseAiToolIds(raw: string | undefined): string[] {
   return raw.split(',').filter(Boolean);
 }
 
+/**
+ * Parses the `page` param into a 1-based page number.
+ * Invalid or missing values default to 1.
+ */
+function parsePage(raw: string | undefined): number {
+  if (!raw) {
+    return 1;
+  }
+
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 1 ? parsed : 1;
+}
+
 // ---------------------------------------------------------------------------
 // Feed (async, Suspense-ready)
 // ---------------------------------------------------------------------------
@@ -64,18 +80,48 @@ function parseAiToolIds(raw: string | undefined): string[] {
  *
  * Accepts optional filters that are forwarded to `getBuilds()`.
  */
-async function Feed({ filters }: { filters?: FeedFiltersType }) {
+async function Feed({ filters }: { filters: FeedFiltersType }) {
   const hasActiveFilters =
-    (filters?.buildTypes?.length ?? 0) > 0 ||
-    (filters?.aiToolIds?.length ?? 0) > 0;
+    (filters.buildTypes?.length ?? 0) > 0 ||
+    (filters.aiToolIds?.length ?? 0) > 0;
 
-  const { data: builds, error } = await getBuilds(filters);
+  const { data: builds, count, error } = await getBuilds(filters);
 
   if (error) {
     throw error;
   }
 
-  return <BuildFeed builds={builds} hasActiveFilters={hasActiveFilters} />;
+  const currentPage = filters.page ?? 1;
+  const totalPages = Math.max(1, Math.ceil(count / BUILDS_PAGE_SIZE));
+
+  // Redirect to the last valid page if the requested page exceeds the total.
+  if (currentPage > totalPages && totalPages > 0) {
+    const params = new URLSearchParams();
+    if (filters.buildTypes?.length) {
+      params.set(BUILD_TYPE_PARAM, filters.buildTypes.join(','));
+    }
+    if (filters.aiToolIds?.length) {
+      params.set(AI_TOOL_PARAM, filters.aiToolIds.join(','));
+    }
+    if (totalPages > 1) {
+      params.set(PAGE_PARAM, String(totalPages));
+    }
+    const queryString = params.toString();
+    redirect(queryString ? `/?${queryString}` : '/');
+  }
+
+  return (
+    <>
+      <BuildFeed builds={builds} hasActiveFilters={hasActiveFilters} />
+      {totalPages > 1 && (
+        <FeedPagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalCount={count}
+        />
+      )}
+    </>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -104,9 +150,11 @@ function FeedSkeleton() {
  * query works without authentication. The `(main)` layout provides shared
  * navigation but does not enforce auth.
  *
- * Filters are read from URL search params and applied server-side:
+ * Filters and pagination are read from URL search params and applied
+ * server-side:
  * - `?buildType=app,feature` — comma-separated build types
  * - `?aiTool=uuid1,uuid2` — comma-separated AI tool IDs
+ * - `?page=2` — 1-based page number (defaults to 1)
  */
 export default async function HomePage({
   searchParams,
@@ -125,18 +173,21 @@ export default async function HomePage({
     typeof resolvedParams[AI_TOOL_PARAM] === 'string'
       ? resolvedParams[AI_TOOL_PARAM]
       : undefined;
+  const rawPage =
+    typeof resolvedParams[PAGE_PARAM] === 'string'
+      ? resolvedParams[PAGE_PARAM]
+      : undefined;
 
   const buildTypes = parseBuildTypes(rawBuildType);
   const aiToolIds = parseAiToolIds(rawAiTool);
+  const page = parsePage(rawPage);
 
-  // Build the filters object. Only include non-empty arrays.
-  const filters: FeedFiltersType | undefined =
-    buildTypes.length > 0 || aiToolIds.length > 0
-      ? {
-          ...(buildTypes.length > 0 && { buildTypes }),
-          ...(aiToolIds.length > 0 && { aiToolIds }),
-        }
-      : undefined;
+  // Build the filters object. Always include page for pagination.
+  const filters: FeedFiltersType = {
+    ...(buildTypes.length > 0 && { buildTypes }),
+    ...(aiToolIds.length > 0 && { aiToolIds }),
+    page,
+  };
 
   // Fetch AI tools for the filter controls (server-side).
   const { data: aiTools, error: aiToolsError } = await getAiTools();
@@ -146,10 +197,11 @@ export default async function HomePage({
   }
 
   // Serialize search params into a stable key so changing filters
-  // triggers a new Suspense boundary and re-shows the skeleton.
+  // or page triggers a new Suspense boundary and re-shows the skeleton.
   const suspenseKey = [
     [...buildTypes].sort().join(','),
     [...aiToolIds].sort().join(','),
+    String(page),
   ].join('|');
 
   return (

--- a/components/feed/feed-pagination.tsx
+++ b/components/feed/feed-pagination.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
+import { PAGE_PARAM } from '@/lib/constants/builds';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+type FeedPaginationProps = {
+  currentPage: number;
+  totalPages: number;
+  totalCount: number;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the page numbers to display. Shows at most 5 page links
+ * with ellipsis when there are many pages.
+ *
+ * Examples (current page marked with *):
+ *   totalPages=5  → [1, 2, 3, 4, 5]
+ *   totalPages=8, page=1  → [1*, 2, 3, ..., 8]
+ *   totalPages=8, page=4  → [1, ..., 3, 4*, 5, ..., 8]
+ *   totalPages=8, page=8  → [1, ..., 6, 7, 8*]
+ */
+function getPageNumbers(
+  currentPage: number,
+  totalPages: number
+): (number | 'ellipsis')[] {
+  // Show all pages when there are 5 or fewer.
+  if (totalPages <= 5) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const pages: (number | 'ellipsis')[] = [];
+
+  // Always show first page.
+  pages.push(1);
+
+  if (currentPage <= 3) {
+    // Near the start: 1, 2, 3, ..., last
+    pages.push(2, 3);
+    pages.push('ellipsis');
+  } else if (currentPage >= totalPages - 2) {
+    // Near the end: 1, ..., n-2, n-1, n
+    pages.push('ellipsis');
+    pages.push(totalPages - 2, totalPages - 1);
+  } else {
+    // Middle: 1, ..., prev, current, next, ..., last
+    pages.push('ellipsis');
+    pages.push(currentPage - 1, currentPage, currentPage + 1);
+    pages.push('ellipsis');
+  }
+
+  // Always show last page.
+  pages.push(totalPages);
+
+  return pages;
+}
+
+// ---------------------------------------------------------------------------
+// FeedPagination
+// ---------------------------------------------------------------------------
+
+/**
+ * Client component that renders pagination controls using shadcn/ui
+ * Pagination primitives. Updates the URL `page` param while
+ * preserving existing filter params.
+ */
+export function FeedPagination({
+  currentPage,
+  totalPages,
+  totalCount,
+}: FeedPaginationProps) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  function buildHref(page: number): string {
+    const params = new URLSearchParams(searchParams.toString());
+
+    // Keep the URL clean — omit the page param when on page 1.
+    if (page <= 1) {
+      params.delete(PAGE_PARAM);
+    } else {
+      params.set(PAGE_PARAM, String(page));
+    }
+
+    const queryString = params.toString();
+    return queryString ? `${pathname}?${queryString}` : pathname;
+  }
+
+  const pageNumbers = getPageNumbers(currentPage, totalPages);
+
+  return (
+    <div className="mt-8 flex flex-col items-center gap-3">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              href={buildHref(currentPage - 1)}
+              aria-disabled={currentPage <= 1}
+              tabIndex={currentPage <= 1 ? -1 : undefined}
+              className={
+                currentPage <= 1 ? 'pointer-events-none opacity-50' : undefined
+              }
+            />
+          </PaginationItem>
+
+          {pageNumbers.map((page, i) =>
+            page === 'ellipsis' ? (
+              <PaginationItem key={`ellipsis-${i}`}>
+                <PaginationEllipsis />
+              </PaginationItem>
+            ) : (
+              <PaginationItem key={page}>
+                <PaginationLink
+                  href={buildHref(page)}
+                  isActive={page === currentPage}
+                >
+                  {page}
+                </PaginationLink>
+              </PaginationItem>
+            )
+          )}
+
+          <PaginationItem>
+            <PaginationNext
+              href={buildHref(currentPage + 1)}
+              aria-disabled={currentPage >= totalPages}
+              tabIndex={currentPage >= totalPages ? -1 : undefined}
+              className={
+                currentPage >= totalPages
+                  ? 'pointer-events-none opacity-50'
+                  : undefined
+              }
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+
+      <p className="text-sm text-muted-foreground">
+        {totalCount} {totalCount === 1 ? 'build' : 'builds'}
+      </p>
+    </div>
+  );
+}

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -1,0 +1,128 @@
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from 'lucide-react';
+import Link from 'next/link';
+import * as React from 'react';
+
+import { type Button, buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn('mx-auto flex w-full justify-center', className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<'ul'>) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn('flex flex-row items-center gap-1', className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
+  return <li data-slot="pagination-item" {...props} />;
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, 'size'> &
+  Omit<React.ComponentProps<typeof Link>, 'ref'>;
+
+function PaginationLink({
+  className,
+  isActive,
+  size = 'icon',
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <Link
+      aria-current={isActive ? 'page' : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? 'outline' : 'ghost',
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn('gap-1 px-2.5 sm:pl-2.5', className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  );
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn('gap-1 px-2.5 sm:pr-2.5', className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  );
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn('flex size-9 items-center justify-center', className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  );
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+};

--- a/lib/constants/builds.ts
+++ b/lib/constants/builds.ts
@@ -32,3 +32,6 @@ export const BUILD_TYPE_PARAM = 'buildType';
 
 /** URL search param key for AI tool filters. */
 export const AI_TOOL_PARAM = 'aiTool';
+
+/** URL search param key for the current page number. */
+export const PAGE_PARAM = 'page';

--- a/lib/queries/builds.ts
+++ b/lib/queries/builds.ts
@@ -47,7 +47,7 @@ const BUILD_WITH_DETAILS_AND_AI_FILTER_SELECT = `
 ` as const;
 
 /** Maximum number of builds returned per page. */
-const BUILDS_PAGE_SIZE = 20;
+export const BUILDS_PAGE_SIZE = 6;
 
 /**
  * Fetches a page of builds for the feed, including the author profile,
@@ -71,6 +71,11 @@ export async function getBuilds(filters?: FeedFilters) {
     : null;
   const activeAiToolIds = filters?.aiToolIds?.length ? filters.aiToolIds : null;
 
+  // Calculate range offsets for the requested page (1-based, defaults to 1).
+  const page = Math.max(1, filters?.page ?? 1);
+  const from = (page - 1) * BUILDS_PAGE_SIZE;
+  const to = from + BUILDS_PAGE_SIZE - 1;
+
   // When filtering by AI tool we use a separate code path that includes
   // an `!inner` join alias (`filter_ai`). This keeps both select strings
   // as compile-time literal types so Supabase's PostgREST type inference
@@ -78,19 +83,19 @@ export async function getBuilds(filters?: FeedFilters) {
   if (activeAiToolIds) {
     let query = supabase
       .from('builds')
-      .select(BUILD_WITH_DETAILS_AND_AI_FILTER_SELECT)
+      .select(BUILD_WITH_DETAILS_AND_AI_FILTER_SELECT, { count: 'exact' })
       .in('filter_ai.ai_tool_id', activeAiToolIds)
       .order('created_at', { ascending: false })
-      .range(0, BUILDS_PAGE_SIZE - 1);
+      .range(from, to);
 
     if (activeBuildTypes) {
       query = query.in('build_type', activeBuildTypes);
     }
 
-    const { data, error } = await query;
+    const { data, count, error } = await query;
 
     if (error) {
-      return { data: null, error };
+      return { data: null, count: 0, error };
     }
 
     const builds: BuildWithDetails[] = (data ?? []).map((build) => {
@@ -98,24 +103,24 @@ export async function getBuilds(filters?: FeedFilters) {
       return { ...rest, upvote_count: build.upvotes[0]?.count ?? 0 };
     });
 
-    return { data: builds, error: null };
+    return { data: builds, count: count ?? 0, error: null };
   }
 
   // No AI tool filter — use the standard select without the extra join.
   let query = supabase
     .from('builds')
-    .select(BUILD_WITH_DETAILS_SELECT)
+    .select(BUILD_WITH_DETAILS_SELECT, { count: 'exact' })
     .order('created_at', { ascending: false })
-    .range(0, BUILDS_PAGE_SIZE - 1);
+    .range(from, to);
 
   if (activeBuildTypes) {
     query = query.in('build_type', activeBuildTypes);
   }
 
-  const { data, error } = await query;
+  const { data, count, error } = await query;
 
   if (error) {
-    return { data: null, error };
+    return { data: null, count: 0, error };
   }
 
   const builds: BuildWithDetails[] = (data ?? []).map((build) => {
@@ -123,7 +128,7 @@ export async function getBuilds(filters?: FeedFilters) {
     return { ...rest, upvote_count: upvotes[0]?.count ?? 0 };
   });
 
-  return { data: builds, error: null };
+  return { data: builds, count: count ?? 0, error: null };
 }
 
 /**

--- a/types/index.ts
+++ b/types/index.ts
@@ -57,6 +57,8 @@ export interface FeedFilters {
   buildTypes?: BuildType[];
   /** Restrict results to builds that use at least one of these AI tools. */
   aiToolIds?: string[];
+  /** 1-based page number for pagination. Defaults to 1 when omitted. */
+  page?: number;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add server-side paginated queries with `?page=N` URL param support
- Create `FeedPagination` component with Previous/Next and page number navigation
- Add shadcn `Pagination` UI primitives
- Export `BUILDS_PAGE_SIZE` and return total count from `getBuilds()`
- Redirect to last valid page when requested page exceeds total
- Reset to page 1 when filters change

## GitHub Issue

Closes #97

## Screenshot

*(drag & drop screenshot here)*

## Test Plan

- [x] Pagination controls appear below the build grid when there are more builds than `BUILDS_PAGE_SIZE`
- [x] Next/Previous navigation works correctly
- [x] Page numbers update in URL
- [x] Filters reset page to 1
- [x] Requesting a page beyond the last redirects to the last valid page

🤖 Generated with [Claude Code](https://claude.com/claude-code)