### PR TITLE
feat(feed): redesign filters — vertical sidebar layout

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -7,9 +7,11 @@ import {
   AI_TOOL_PARAM,
   BUILD_TYPE_LABELS,
   BUILD_TYPE_PARAM,
+  TECH_STACK_PARAM,
 } from '@/lib/constants/builds';
 import { getAiTools } from '@/lib/queries/ai-tools';
 import { getBuilds } from '@/lib/queries/builds';
+import { getTechStackTags } from '@/lib/queries/tech-stack-tags';
 import type { BuildType, FeedFilters as FeedFiltersType } from '@/types';
 
 // ---------------------------------------------------------------------------
@@ -41,11 +43,10 @@ function parseBuildTypes(raw: string | undefined): BuildType[] {
 }
 
 /**
- * Parses a comma-separated `aiTool` param into an array of IDs.
- * Returns the raw split — server-side validation happens in the query
- * (non-matching IDs simply return no results).
+ * Parses a comma-separated ID param into an array of strings.
+ * Returns the raw split — server-side validation happens in the query.
  */
-function parseAiToolIds(raw: string | undefined): string[] {
+function parseIds(raw: string | undefined): string[] {
   if (!raw) {
     return [];
   }
@@ -67,7 +68,8 @@ function parseAiToolIds(raw: string | undefined): string[] {
 async function Feed({ filters }: { filters?: FeedFiltersType }) {
   const hasActiveFilters =
     (filters?.buildTypes?.length ?? 0) > 0 ||
-    (filters?.aiToolIds?.length ?? 0) > 0;
+    (filters?.aiToolIds?.length ?? 0) > 0 ||
+    (filters?.techStackTagIds?.length ?? 0) > 0;
 
   const { data: builds, error } = await getBuilds(filters);
 
@@ -125,24 +127,36 @@ export default async function HomePage({
     typeof resolvedParams[AI_TOOL_PARAM] === 'string'
       ? resolvedParams[AI_TOOL_PARAM]
       : undefined;
+  const rawTechStack =
+    typeof resolvedParams[TECH_STACK_PARAM] === 'string'
+      ? resolvedParams[TECH_STACK_PARAM]
+      : undefined;
 
   const buildTypes = parseBuildTypes(rawBuildType);
-  const aiToolIds = parseAiToolIds(rawAiTool);
+  const aiToolIds = parseIds(rawAiTool);
+  const techStackTagIds = parseIds(rawTechStack);
 
   // Build the filters object. Only include non-empty arrays.
   const filters: FeedFiltersType | undefined =
-    buildTypes.length > 0 || aiToolIds.length > 0
+    buildTypes.length > 0 || aiToolIds.length > 0 || techStackTagIds.length > 0
       ? {
           ...(buildTypes.length > 0 && { buildTypes }),
           ...(aiToolIds.length > 0 && { aiToolIds }),
+          ...(techStackTagIds.length > 0 && { techStackTagIds }),
         }
       : undefined;
 
-  // Fetch AI tools for the filter controls (server-side).
-  const { data: aiTools, error: aiToolsError } = await getAiTools();
+  // Fetch AI tools and tech stack tags for the filter controls (server-side).
+  const [
+    { data: aiTools, error: aiToolsError },
+    { data: techStackTags, error: techStackTagsError },
+  ] = await Promise.all([getAiTools(), getTechStackTags()]);
 
   if (aiToolsError) {
     throw aiToolsError;
+  }
+  if (techStackTagsError) {
+    throw techStackTagsError;
   }
 
   // Serialize search params into a stable key so changing filters
@@ -150,6 +164,7 @@ export default async function HomePage({
   const suspenseKey = [
     [...buildTypes].sort().join(','),
     [...aiToolIds].sort().join(','),
+    [...techStackTagIds].sort().join(','),
   ].join('|');
 
   return (
@@ -173,7 +188,10 @@ export default async function HomePage({
 
       {/* FeedFilters uses useSearchParams() so it needs its own Suspense boundary */}
       <Suspense fallback={null}>
-        <FeedFilters aiTools={aiTools ?? []} />
+        <FeedFilters
+          aiTools={aiTools ?? []}
+          techStackTags={techStackTags ?? []}
+        />
       </Suspense>
 
       <div className="mt-6">

--- a/components/feed/feed-filters.tsx
+++ b/components/feed/feed-filters.tsx
@@ -24,9 +24,10 @@ import {
   AI_TOOL_PARAM,
   BUILD_TYPE_LABELS,
   BUILD_TYPE_PARAM,
+  TECH_STACK_PARAM,
 } from '@/lib/constants/builds';
 import { cn } from '@/lib/utils';
-import type { AiTool, BuildType } from '@/types';
+import type { AiTool, BuildType, TechStackTag } from '@/types';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -42,6 +43,8 @@ const BUILD_TYPES = Object.keys(BUILD_TYPE_LABELS) as BuildType[];
 interface FeedFiltersProps {
   /** Available AI tools, passed from the server page component. */
   aiTools: AiTool[];
+  /** Available tech stack tags, passed from the server page component. */
+  techStackTags: TechStackTag[];
 }
 
 // ---------------------------------------------------------------------------
@@ -49,21 +52,24 @@ interface FeedFiltersProps {
 // ---------------------------------------------------------------------------
 
 /**
- * Client component that renders filter controls for the home feed.
+ * Client component that renders three dropdown filter controls for the home feed.
  *
- * - Build Type toggle buttons for all 5 types
- * - AI Tool multi-select using Popover + Command
+ * - Build Type multi-select dropdown
+ * - Tech Stack multi-select dropdown
+ * - AI Tool multi-select dropdown
  * - Active filter badges with individual dismiss buttons
  * - "Clear all" button when any filter is active
  *
  * Filter state is stored in URL search params so the server page
  * component can read them and pass to `getBuilds()`.
  */
-export function FeedFilters({ aiTools }: FeedFiltersProps) {
+export function FeedFilters({ aiTools, techStackTags }: FeedFiltersProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
+  const [buildTypePopoverOpen, setBuildTypePopoverOpen] = useState(false);
+  const [techStackPopoverOpen, setTechStackPopoverOpen] = useState(false);
   const [aiToolPopoverOpen, setAiToolPopoverOpen] = useState(false);
 
   // -------------------------------------------------------------------------
@@ -71,28 +77,40 @@ export function FeedFilters({ aiTools }: FeedFiltersProps) {
   // -------------------------------------------------------------------------
 
   const activeBuildTypes = parseBuildTypes(searchParams.get(BUILD_TYPE_PARAM));
-  const activeAiToolIds = parseAiToolIds(
+  const activeAiToolIds = parseIds(
     searchParams.get(AI_TOOL_PARAM),
-    aiTools
+    aiTools.map((t) => t.id)
+  );
+  const activeTechStackTagIds = parseIds(
+    searchParams.get(TECH_STACK_PARAM),
+    techStackTags.map((t) => t.id)
   );
 
   const hasActiveFilters =
-    activeBuildTypes.length > 0 || activeAiToolIds.length > 0;
+    activeBuildTypes.length > 0 ||
+    activeAiToolIds.length > 0 ||
+    activeTechStackTagIds.length > 0;
 
   // -------------------------------------------------------------------------
   // URL update helper
   // -------------------------------------------------------------------------
 
   const updateUrl = useCallback(
-    (buildTypes: BuildType[], aiToolIds: string[]) => {
+    (
+      buildTypes: BuildType[],
+      aiToolIds: string[],
+      techStackTagIds: string[]
+    ) => {
       const params = new URLSearchParams();
 
       if (buildTypes.length > 0) {
         params.set(BUILD_TYPE_PARAM, buildTypes.join(','));
       }
-
       if (aiToolIds.length > 0) {
         params.set(AI_TOOL_PARAM, aiToolIds.join(','));
+      }
+      if (techStackTagIds.length > 0) {
+        params.set(TECH_STACK_PARAM, techStackTagIds.join(','));
       }
 
       const queryString = params.toString();
@@ -104,57 +122,43 @@ export function FeedFilters({ aiTools }: FeedFiltersProps) {
   );
 
   // -------------------------------------------------------------------------
-  // Build Type toggle handlers
+  // Toggle handlers
   // -------------------------------------------------------------------------
 
   function toggleBuildType(type: BuildType) {
     const next = activeBuildTypes.includes(type)
       ? activeBuildTypes.filter((t) => t !== type)
       : [...activeBuildTypes, type];
-
-    updateUrl(next, activeAiToolIds);
+    updateUrl(next, activeAiToolIds, activeTechStackTagIds);
   }
-
-  function removeBuildType(type: BuildType) {
-    updateUrl(
-      activeBuildTypes.filter((t) => t !== type),
-      activeAiToolIds
-    );
-  }
-
-  // -------------------------------------------------------------------------
-  // AI Tool toggle handlers
-  // -------------------------------------------------------------------------
 
   function toggleAiTool(toolId: string) {
     const next = activeAiToolIds.includes(toolId)
       ? activeAiToolIds.filter((id) => id !== toolId)
       : [...activeAiToolIds, toolId];
-
-    updateUrl(activeBuildTypes, next);
+    updateUrl(activeBuildTypes, next, activeTechStackTagIds);
   }
 
-  function removeAiTool(toolId: string) {
-    updateUrl(
-      activeBuildTypes,
-      activeAiToolIds.filter((id) => id !== toolId)
-    );
+  function toggleTechStack(tagId: string) {
+    const next = activeTechStackTagIds.includes(tagId)
+      ? activeTechStackTagIds.filter((id) => id !== tagId)
+      : [...activeTechStackTagIds, tagId];
+    updateUrl(activeBuildTypes, activeAiToolIds, next);
   }
-
-  // -------------------------------------------------------------------------
-  // Clear all filters
-  // -------------------------------------------------------------------------
 
   function clearAll() {
-    updateUrl([], []);
+    updateUrl([], [], []);
   }
 
   // -------------------------------------------------------------------------
-  // Derived data for AI Tool display
+  // Derived data for badge display
   // -------------------------------------------------------------------------
 
   const selectedAiTools = aiTools.filter((tool) =>
     activeAiToolIds.includes(tool.id)
+  );
+  const selectedTechStackTags = techStackTags.filter((tag) =>
+    activeTechStackTagIds.includes(tag.id)
   );
 
   // -------------------------------------------------------------------------
@@ -165,26 +169,99 @@ export function FeedFilters({ aiTools }: FeedFiltersProps) {
     <div className="space-y-3 pb-2">
       {/* Filter controls row */}
       <div className="flex flex-wrap items-center gap-3">
-        {/* Build Type toggles */}
-        <div className="flex flex-wrap gap-1.5">
-          {BUILD_TYPES.map((type) => {
-            const isActive = activeBuildTypes.includes(type);
+        {/* Build Type dropdown */}
+        <Popover
+          open={buildTypePopoverOpen}
+          onOpenChange={setBuildTypePopoverOpen}
+        >
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              role="combobox"
+              aria-expanded={buildTypePopoverOpen}
+              className={cn(
+                'justify-between',
+                activeBuildTypes.length === 0 && 'text-muted-foreground'
+              )}
+            >
+              {activeBuildTypes.length > 0
+                ? `${activeBuildTypes.length} build type${activeBuildTypes.length === 1 ? '' : 's'}`
+                : 'Build Type'}
+              <ChevronsUpDownIcon className="opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-48 p-0" align="start">
+            <Command>
+              <CommandList>
+                <CommandGroup>
+                  {BUILD_TYPES.map((type) => {
+                    const isSelected = activeBuildTypes.includes(type);
+                    return (
+                      <CommandItem
+                        key={type}
+                        value={type}
+                        onSelect={() => toggleBuildType(type)}
+                      >
+                        <CommandCheckbox isSelected={isSelected} />
+                        {BUILD_TYPE_LABELS[type]}
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
 
-            return (
-              <Button
-                key={type}
-                variant={isActive ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => toggleBuildType(type)}
-                aria-pressed={isActive}
-              >
-                {BUILD_TYPE_LABELS[type]}
-              </Button>
-            );
-          })}
-        </div>
+        {/* Tech Stack dropdown */}
+        <Popover
+          open={techStackPopoverOpen}
+          onOpenChange={setTechStackPopoverOpen}
+        >
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              role="combobox"
+              aria-expanded={techStackPopoverOpen}
+              className={cn(
+                'justify-between',
+                activeTechStackTagIds.length === 0 && 'text-muted-foreground'
+              )}
+            >
+              {activeTechStackTagIds.length > 0
+                ? `${activeTechStackTagIds.length} tech stack${activeTechStackTagIds.length === 1 ? '' : 's'}`
+                : 'Tech Stack'}
+              <ChevronsUpDownIcon className="opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-56 p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Search tech stack..." />
+              <CommandList>
+                <CommandEmpty>No tech stack found.</CommandEmpty>
+                <CommandGroup>
+                  {techStackTags.map((tag) => {
+                    const isSelected = activeTechStackTagIds.includes(tag.id);
+                    return (
+                      <CommandItem
+                        key={tag.id}
+                        value={tag.name}
+                        onSelect={() => toggleTechStack(tag.id)}
+                      >
+                        <CommandCheckbox isSelected={isSelected} />
+                        {tag.name}
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
 
-        {/* AI Tool multi-select */}
+        {/* AI Tools dropdown */}
         <Popover open={aiToolPopoverOpen} onOpenChange={setAiToolPopoverOpen}>
           <PopoverTrigger asChild>
             <Button
@@ -211,7 +288,6 @@ export function FeedFilters({ aiTools }: FeedFiltersProps) {
                 <CommandGroup>
                   {aiTools.map((tool) => {
                     const isSelected = activeAiToolIds.includes(tool.id);
-
                     return (
                       <CommandItem
                         key={tool.id}
@@ -251,8 +327,33 @@ export function FeedFilters({ aiTools }: FeedFiltersProps) {
               <button
                 type="button"
                 className="ml-1 rounded-full outline-none hover:text-foreground"
-                onClick={() => removeBuildType(type)}
+                onClick={() =>
+                  updateUrl(
+                    activeBuildTypes.filter((t) => t !== type),
+                    activeAiToolIds,
+                    activeTechStackTagIds
+                  )
+                }
                 aria-label={`Remove ${BUILD_TYPE_LABELS[type]} filter`}
+              >
+                <XIcon className="size-3" />
+              </button>
+            </Badge>
+          ))}
+          {selectedTechStackTags.map((tag) => (
+            <Badge key={tag.id} variant="secondary">
+              {tag.name}
+              <button
+                type="button"
+                className="ml-1 rounded-full outline-none hover:text-foreground"
+                onClick={() =>
+                  updateUrl(
+                    activeBuildTypes,
+                    activeAiToolIds,
+                    activeTechStackTagIds.filter((id) => id !== tag.id)
+                  )
+                }
+                aria-label={`Remove ${tag.name} filter`}
               >
                 <XIcon className="size-3" />
               </button>
@@ -264,7 +365,13 @@ export function FeedFilters({ aiTools }: FeedFiltersProps) {
               <button
                 type="button"
                 className="ml-1 rounded-full outline-none hover:text-foreground"
-                onClick={() => removeAiTool(tool.id)}
+                onClick={() =>
+                  updateUrl(
+                    activeBuildTypes,
+                    activeAiToolIds.filter((id) => id !== tool.id),
+                    activeTechStackTagIds
+                  )
+                }
                 aria-label={`Remove ${tool.name} filter`}
               >
                 <XIcon className="size-3" />
@@ -281,35 +388,20 @@ export function FeedFilters({ aiTools }: FeedFiltersProps) {
 // URL param parsing helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Parses a comma-separated `buildType` param value into valid BuildType values.
- * Invalid values are silently dropped.
- */
 function parseBuildTypes(raw: string | null): BuildType[] {
   if (!raw) {
     return [];
   }
-
   const validTypes = new Set<string>(BUILD_TYPES);
-
   return raw
     .split(',')
     .filter((value): value is BuildType => validTypes.has(value));
 }
 
-/**
- * Parses a comma-separated `aiTool` param value into valid AI tool IDs.
- * IDs not found in the available tools list are silently dropped.
- */
-function parseAiToolIds(
-  raw: string | null,
-  availableTools: AiTool[]
-): string[] {
+function parseIds(raw: string | null, validIdList: string[]): string[] {
   if (!raw) {
     return [];
   }
-
-  const validIds = new Set(availableTools.map((tool) => tool.id));
-
+  const validIds = new Set(validIdList);
   return raw.split(',').filter((id) => validIds.has(id));
 }

--- a/lib/constants/builds.ts
+++ b/lib/constants/builds.ts
@@ -32,3 +32,6 @@ export const BUILD_TYPE_PARAM = 'buildType';
 
 /** URL search param key for AI tool filters. */
 export const AI_TOOL_PARAM = 'aiTool';
+
+/** URL search param key for tech stack tag filters. */
+export const TECH_STACK_PARAM = 'techStack';

--- a/lib/queries/builds.ts
+++ b/lib/queries/builds.ts
@@ -46,6 +46,44 @@ const BUILD_WITH_DETAILS_AND_AI_FILTER_SELECT = `
   filter_ai:build_ai_tools!inner(ai_tool_id)
 ` as const;
 
+/**
+ * Select string that includes an additional `!inner` join on `build_tech_stack_tags`
+ * for filtering by tech stack. The alias `filter_tech` restricts parent rows to those
+ * with at least one matching tech stack tag.
+ */
+const BUILD_WITH_DETAILS_AND_TECH_FILTER_SELECT = `
+  *,
+  profile:profiles!builds_user_id_fkey(*),
+  screenshots:build_screenshots(*),
+  ai_tools:build_ai_tools(
+    ...ai_tools(*)
+  ),
+  tech_stack_tags:build_tech_stack_tags(
+    ...tech_stack_tags(*)
+  ),
+  upvotes:upvotes(count),
+  filter_tech:build_tech_stack_tags!inner(tech_stack_tag_id)
+` as const;
+
+/**
+ * Select string that includes `!inner` joins on both `build_ai_tools` and
+ * `build_tech_stack_tags` for filtering by both AI tool and tech stack simultaneously.
+ */
+const BUILD_WITH_DETAILS_AND_BOTH_FILTER_SELECT = `
+  *,
+  profile:profiles!builds_user_id_fkey(*),
+  screenshots:build_screenshots(*),
+  ai_tools:build_ai_tools(
+    ...ai_tools(*)
+  ),
+  tech_stack_tags:build_tech_stack_tags(
+    ...tech_stack_tags(*)
+  ),
+  upvotes:upvotes(count),
+  filter_ai:build_ai_tools!inner(ai_tool_id),
+  filter_tech:build_tech_stack_tags!inner(tech_stack_tag_id)
+` as const;
+
 /** Maximum number of builds returned per page. */
 const BUILDS_PAGE_SIZE = 20;
 
@@ -70,11 +108,43 @@ export async function getBuilds(filters?: FeedFilters) {
     ? filters.buildTypes
     : null;
   const activeAiToolIds = filters?.aiToolIds?.length ? filters.aiToolIds : null;
+  const activeTechStackTagIds = filters?.techStackTagIds?.length
+    ? filters.techStackTagIds
+    : null;
 
-  // When filtering by AI tool we use a separate code path that includes
-  // an `!inner` join alias (`filter_ai`). This keeps both select strings
-  // as compile-time literal types so Supabase's PostgREST type inference
-  // works correctly in each branch.
+  // When filtering by both AI tool and tech stack, use the combined select.
+  if (activeAiToolIds && activeTechStackTagIds) {
+    let query = supabase
+      .from('builds')
+      .select(BUILD_WITH_DETAILS_AND_BOTH_FILTER_SELECT)
+      .in('filter_ai.ai_tool_id', activeAiToolIds)
+      .in('filter_tech.tech_stack_tag_id', activeTechStackTagIds)
+      .order('created_at', { ascending: false })
+      .range(0, BUILDS_PAGE_SIZE - 1);
+
+    if (activeBuildTypes) {
+      query = query.in('build_type', activeBuildTypes);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      return { data: null, error };
+    }
+
+    const builds: BuildWithDetails[] = (data ?? []).map((build) => {
+      const {
+        filter_ai: _filter_ai,
+        filter_tech: _filter_tech,
+        ...rest
+      } = build;
+      return { ...rest, upvote_count: build.upvotes[0]?.count ?? 0 };
+    });
+
+    return { data: builds, error: null };
+  }
+
+  // When filtering by AI tool only.
   if (activeAiToolIds) {
     let query = supabase
       .from('builds')
@@ -101,7 +171,34 @@ export async function getBuilds(filters?: FeedFilters) {
     return { data: builds, error: null };
   }
 
-  // No AI tool filter — use the standard select without the extra join.
+  // When filtering by tech stack only.
+  if (activeTechStackTagIds) {
+    let query = supabase
+      .from('builds')
+      .select(BUILD_WITH_DETAILS_AND_TECH_FILTER_SELECT)
+      .in('filter_tech.tech_stack_tag_id', activeTechStackTagIds)
+      .order('created_at', { ascending: false })
+      .range(0, BUILDS_PAGE_SIZE - 1);
+
+    if (activeBuildTypes) {
+      query = query.in('build_type', activeBuildTypes);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      return { data: null, error };
+    }
+
+    const builds: BuildWithDetails[] = (data ?? []).map((build) => {
+      const { filter_tech: _filter_tech, ...rest } = build;
+      return { ...rest, upvote_count: build.upvotes[0]?.count ?? 0 };
+    });
+
+    return { data: builds, error: null };
+  }
+
+  // No AI tool or tech stack filter — use the standard select without extra joins.
   let query = supabase
     .from('builds')
     .select(BUILD_WITH_DETAILS_SELECT)

--- a/types/index.ts
+++ b/types/index.ts
@@ -57,6 +57,8 @@ export interface FeedFilters {
   buildTypes?: BuildType[];
   /** Restrict results to builds that use at least one of these AI tools. */
   aiToolIds?: string[];
+  /** Restrict results to builds that use at least one of these tech stack tags. */
+  techStackTagIds?: string[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace build type toggle buttons with a multi-select dropdown
- Add a new Tech Stack multi-select dropdown filter
- Keep AI Tools multi-select dropdown (unchanged behaviour)
- Wire up tech stack filtering in `getBuilds()` query with `!inner` join
- Pass `techStackTags` from server page to `FeedFilters` component

## GitHub Issue

Closes #69

## Test Plan

- [ ] Build Type dropdown shows all 5 options (App, Feature, Fix, Automation, Experiment) and supports multi-select
- [ ] Tech Stack dropdown shows all tags and supports multi-select
- [ ] AI Tools dropdown works as before
- [ ] Active filter badges appear and can be individually dismissed
- [ ] Clear all button clears all filters
- [ ] Combining all 3 filters returns correct results
- [ ] URL search params are preserved (shareable URLs work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)