### PR TITLE
feat(upvotes): redesign upvote UI to blend inline like Reddit/Instagram

### DIFF
--- a/app/(main)/builds/[id]/page.tsx
+++ b/app/(main)/builds/[id]/page.tsx
@@ -4,9 +4,9 @@ import { notFound } from 'next/navigation';
 
 import { BuildOwnerActions } from '@/components/builds/build-owner-actions';
 import { ScreenshotGallery } from '@/components/builds/screenshot-gallery';
+import { UpvoteButton } from '@/components/builds/upvote-button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { UpvoteIcon } from '@/components/ui/icons';
 import { getUser } from '@/lib/auth';
 import {
   BUILD_TYPE_BADGE_CLASSES,
@@ -14,6 +14,7 @@ import {
 } from '@/lib/constants/builds';
 import { profileRoute, Routes } from '@/lib/constants/routes';
 import { getBuildById } from '@/lib/queries/builds';
+import { hasUserUpvoted } from '@/lib/queries/upvotes';
 import { cn, isUuid } from '@/lib/utils';
 
 type BuildDetailPageProps = {
@@ -39,6 +40,9 @@ export default async function BuildDetailPage({
   }
 
   const isOwner = user?.id === build.user_id;
+  const { data: userHasUpvoted } = user
+    ? await hasUserUpvoted(id, user.id)
+    : { data: false };
   const profile = build.profile;
 
   const sortedScreenshots = [...build.screenshots].sort(
@@ -127,50 +131,41 @@ export default async function BuildDetailPage({
             </div>
           )}
 
-          {/* Links */}
-          {(build.live_url || build.repo_url) && (
-            <div className="mb-8 flex flex-wrap gap-3">
-              {build.repo_url && (
-                <a
-                  href={build.repo_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/80"
-                >
-                  <ExternalLinkIcon className="size-4" />
-                  View Repo
-                </a>
-              )}
-              {build.live_url && (
-                <a
-                  href={build.live_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-zinc-300 hover:bg-muted"
-                >
-                  <ExternalLinkIcon className="size-4" />
-                  Live Demo
-                </a>
-              )}
-            </div>
-          )}
+          {/* Links + Upvote */}
+          <div className="mb-8 flex flex-wrap items-center gap-3">
+            {build.repo_url && (
+              <a
+                href={build.repo_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/80"
+              >
+                <ExternalLinkIcon className="size-4" />
+                View Repo
+              </a>
+            )}
+            {build.live_url && (
+              <a
+                href={build.live_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-zinc-300 hover:bg-muted"
+              >
+                <ExternalLinkIcon className="size-4" />
+                Live Demo
+              </a>
+            )}
+            <UpvoteButton
+              buildId={build.id}
+              initialCount={build.upvote_count}
+              initialUpvoted={userHasUpvoted}
+              isAuthenticated={!!user}
+            />
+          </div>
         </div>
 
         {/* -- Sidebar -- */}
         <div className="flex flex-col gap-4 lg:col-span-1">
-          {/* Upvote Widget */}
-          <div className="rounded-xl border border-border bg-card p-6 text-center">
-            <div className="flex flex-col items-center gap-2">
-              <div className="flex size-14 items-center justify-center rounded-xl border-2 border-amber-600 bg-amber-50">
-                <UpvoteIcon size={24} className="text-amber-600" />
-              </div>
-              <span className="font-display text-2xl text-foreground">
-                {build.upvote_count}
-              </span>
-              <span className="text-xs text-muted-foreground">upvotes</span>
-            </div>
-          </div>
-
           {/* AI Tools card */}
           {build.ai_tools.length > 0 && (
             <div className="rounded-xl border border-border bg-card p-6">

--- a/app/actions/upvotes.ts
+++ b/app/actions/upvotes.ts
@@ -1,0 +1,21 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { requireUser } from '@/lib/auth';
+import { toggleUpvote } from '@/lib/queries/upvotes';
+
+export async function toggleUpvoteAction(buildId: string) {
+  const user = await requireUser();
+
+  const { data, error } = await toggleUpvote(buildId, user.id);
+
+  if (error) {
+    throw new Error('Failed to toggle upvote');
+  }
+
+  revalidatePath(`/builds/${buildId}`);
+  revalidatePath('/');
+
+  return data;
+}

--- a/components/builds/upvote-button.tsx
+++ b/components/builds/upvote-button.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useOptimistic, useTransition } from 'react';
+
+import { toggleUpvoteAction } from '@/app/actions/upvotes';
+import { UpvoteIcon } from '@/components/ui/icons';
+import { cn } from '@/lib/utils';
+
+type UpvoteButtonProps = {
+  buildId: string;
+  initialCount: number;
+  initialUpvoted: boolean;
+  isAuthenticated: boolean;
+};
+
+export function UpvoteButton({
+  buildId,
+  initialCount,
+  initialUpvoted,
+  isAuthenticated,
+}: UpvoteButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const [optimistic, setOptimistic] = useOptimistic(
+    { upvoted: initialUpvoted, count: initialCount },
+    (current) => ({
+      upvoted: !current.upvoted,
+      count: current.upvoted ? current.count - 1 : current.count + 1,
+    })
+  );
+
+  function handleClick() {
+    if (!isAuthenticated) return;
+
+    startTransition(async () => {
+      setOptimistic(null);
+      await toggleUpvoteAction(buildId);
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={!isAuthenticated || isPending}
+      aria-label={optimistic.upvoted ? 'Remove upvote' : 'Upvote this build'}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-150',
+        optimistic.upvoted
+          ? 'border-amber-500/40 bg-amber-50 text-amber-700 hover:bg-amber-100'
+          : 'border-border bg-muted text-muted-foreground hover:border-amber-500/40 hover:text-amber-700',
+        !isAuthenticated && 'cursor-not-allowed opacity-50',
+        isPending && 'pointer-events-none'
+      )}
+    >
+      <UpvoteIcon
+        size={14}
+        className={cn(
+          'transition-colors',
+          optimistic.upvoted ? 'text-amber-600' : ''
+        )}
+      />
+      <span className="tabular-nums">{optimistic.count}</span>
+    </button>
+  );
+}

--- a/components/feed/build-card.tsx
+++ b/components/feed/build-card.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { CheckerboardPlaceholder } from '@/components/ui/checkerboard-placeholder';
+import { UpvoteIcon } from '@/components/ui/icons';
 import {
   BUILD_TYPE_BADGE_CLASSES,
   BUILD_TYPE_LABELS,
@@ -100,7 +101,7 @@ export function BuildCard({ build }: BuildCardProps) {
             {build.description}
           </p>
 
-          {/* Footer: avatar + name */}
+          {/* Footer: avatar + name + upvotes */}
           <div className="flex items-center justify-between">
             {profile ? (
               <div className="flex items-center gap-2">
@@ -122,6 +123,10 @@ export function BuildCard({ build }: BuildCardProps) {
             ) : (
               <span className="text-xs text-muted-foreground">Anonymous</span>
             )}
+            <div className="flex items-center gap-1 text-muted-foreground">
+              <UpvoteIcon size={12} />
+              <span className="text-xs tabular-nums">{build.upvote_count}</span>
+            </div>
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Summary
- Removed standalone upvote card from sidebar on build detail page
- Added inline `UpvoteButton` component with optimistic updates via `useOptimistic`
- Created `toggleUpvoteAction` server action for upvote toggling with path revalidation
- Added upvote count display on feed build cards for consistency

## GitHub Issue
Closes #74

## Test Plan
- [ ] Navigate to a build detail page — upvote button appears inline next to View Repo / Live Demo links
- [ ] Click upvote button while logged in — count updates instantly (optimistic), persists after reload
- [ ] Click again to remove upvote — count decrements
- [ ] Verify button shows "upvoted" amber state when active
- [ ] Verify button is disabled/not-allowed when logged out
- [ ] Check feed cards show upvote count with icon
- [ ] Test keyboard accessibility (tab + enter to toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)