### PR TITLE
refactor(profile): redesign profile header layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import { DM_Serif_Display, Geist, Geist_Mono } from 'next/font/google';
 
 import { Toaster } from '@/components/ui/sonner';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -36,8 +37,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${dmSerifDisplay.variable} antialiased`}
       >
-        {children}
-        <Toaster />
+        <TooltipProvider>
+          {children}
+          <Toaster />
+        </TooltipProvider>
       </body>
     </html>
   );

--- a/components/profile/profile-header.tsx
+++ b/components/profile/profile-header.tsx
@@ -9,7 +9,6 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { Routes } from '@/lib/constants/routes';
-import { cn } from '@/lib/utils';
 import type { Profile } from '@/types';
 
 // ---------------------------------------------------------------------------
@@ -64,14 +63,10 @@ export function ProfileHeader({
       {/* Content area — left-aligned */}
       <div className="px-6 pb-6">
         {/* Top row: Avatar left, Stats right */}
-        <div className="flex items-start justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           {/* Avatar with edit overlay */}
           <div className="relative -mt-12 w-fit">
-            <Avatar
-              className={cn(
-                'size-24 shrink-0 rounded-2xl ring-4 ring-background shadow-lg'
-              )}
-            >
+            <Avatar className="size-24 rounded-2xl ring-4 ring-background shadow-lg">
               {profile.avatar_url && (
                 <AvatarImage src={profile.avatar_url} alt={displayName} />
               )}
@@ -85,9 +80,10 @@ export function ProfileHeader({
                 <TooltipTrigger asChild>
                   <Link
                     href={Routes.PROFILE_SETTINGS}
+                    aria-label="Edit profile"
                     className="absolute bottom-0 right-0 flex size-8 items-center justify-center rounded-lg border border-border bg-muted shadow-lg transition-all hover:scale-110 hover:bg-accent"
                   >
-                    <PencilIcon className="size-3.5 text-foreground" />
+                    <PencilIcon aria-hidden className="size-3.5" />
                   </Link>
                 </TooltipTrigger>
                 <TooltipContent>Edit Profile</TooltipContent>

--- a/components/profile/profile-header.tsx
+++ b/components/profile/profile-header.tsx
@@ -2,8 +2,12 @@ import { Github, Globe, Linkedin, PencilIcon } from 'lucide-react';
 import Link from 'next/link';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Button } from '@/components/ui/button';
 import { XTwitterIcon } from '@/components/ui/icons';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { Routes } from '@/lib/constants/routes';
 import { cn } from '@/lib/utils';
 import type { Profile } from '@/types';
@@ -53,96 +57,92 @@ export function ProfileHeader({
   const displayName = profile.display_name ?? 'Anonymous';
 
   return (
-    <div>
-      {/* Card wrapper */}
-      <div className="overflow-hidden rounded-2xl border border-border bg-card">
-        {/* Cover gradient */}
-        <div className="h-32 bg-gradient-to-r from-zinc-800 via-zinc-700 to-zinc-900" />
+    <div className="overflow-hidden rounded-2xl border border-border bg-card">
+      {/* Cover gradient */}
+      <div className="h-32 bg-gradient-to-r from-zinc-800 via-zinc-700 to-zinc-900" />
 
-        {/* Content area below cover */}
-        <div className="px-6 pb-6">
-          <div className="flex flex-col gap-6 sm:flex-row sm:items-end">
-            {/* Left: Avatar + info */}
-            <div className="flex min-w-0 flex-1 flex-col gap-4 sm:flex-row sm:items-end">
-              {/* Avatar — overlaps cover with ring */}
-              <Avatar
-                className={cn(
-                  'size-24 -mt-12 shrink-0 rounded-2xl ring-4 ring-background shadow-lg'
-                )}
-              >
-                {profile.avatar_url && (
-                  <AvatarImage src={profile.avatar_url} alt={displayName} />
-                )}
-                <AvatarFallback className="rounded-2xl text-2xl">
-                  {displayName.charAt(0).toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
+      {/* Content area — left-aligned */}
+      <div className="px-6 pb-6">
+        {/* Top row: Avatar left, Stats right */}
+        <div className="flex items-start justify-between">
+          {/* Avatar with edit overlay */}
+          <div className="relative -mt-12 w-fit">
+            <Avatar
+              className={cn(
+                'size-24 shrink-0 rounded-2xl ring-4 ring-background shadow-lg'
+              )}
+            >
+              {profile.avatar_url && (
+                <AvatarImage src={profile.avatar_url} alt={displayName} />
+              )}
+              <AvatarFallback className="rounded-2xl text-2xl">
+                {displayName.charAt(0).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
 
-              {/* Name, bio, and social links */}
-              <div className="min-w-0 pb-1">
-                <h1 className="font-display text-2xl text-foreground">
-                  {displayName}
-                </h1>
+            {isOwner && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    href={Routes.PROFILE_SETTINGS}
+                    className="absolute bottom-0 right-0 flex size-8 items-center justify-center rounded-lg border border-border bg-muted shadow-lg transition-all hover:scale-110 hover:bg-accent"
+                  >
+                    <PencilIcon className="size-3.5 text-foreground" />
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent>Edit Profile</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
 
-                {profile.bio && (
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    {profile.bio}
-                  </p>
-                )}
-
-                {/* Social links — inline with text labels */}
-                <div className="mt-3">
-                  <SocialLinks profile={profile} />
-                </div>
-
-                <p className="mt-2 font-mono text-xs text-muted-foreground">
-                  Joined{' '}
-                  {new Date(profile.created_at).toLocaleDateString('en-US', {
-                    month: 'long',
-                    year: 'numeric',
-                  })}
-                </p>
+          {/* Stats */}
+          <div className="mt-3 flex items-center gap-6">
+            <div className="text-center">
+              <div className="font-display text-2xl text-foreground">
+                {buildsCount}
+              </div>
+              <div className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                Builds
               </div>
             </div>
 
-            {/* Right: Stats */}
-            <div className="flex shrink-0 items-center gap-6 pb-1">
-              <div className="text-center">
-                <div className="font-display text-2xl text-foreground">
-                  {buildsCount}
-                </div>
-                <div className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-                  Builds
-                </div>
+            <div className="h-10 w-px bg-border" />
+
+            <div className="text-center">
+              <div className="font-display text-2xl text-foreground">
+                {totalUpvotes}
               </div>
-
-              {/* Divider */}
-              <div className="h-10 w-px bg-border" />
-
-              <div className="text-center">
-                <div className="font-display text-2xl text-foreground">
-                  {totalUpvotes}
-                </div>
-                <div className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-                  Upvotes
-                </div>
+              <div className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                Upvotes
               </div>
             </div>
           </div>
         </div>
-      </div>
 
-      {/* Edit Profile — below card, only shown to profile owner */}
-      {isOwner && (
-        <div className="mt-4">
-          <Button variant="outline" size="sm" asChild>
-            <Link href={Routes.PROFILE_SETTINGS}>
-              <PencilIcon />
-              Edit Profile
-            </Link>
-          </Button>
+        {/* Name */}
+        <h1 className="mt-4 font-display text-2xl text-foreground">
+          {displayName}
+        </h1>
+
+        {/* Bio */}
+        {profile.bio && (
+          <p className="mt-1 text-sm text-muted-foreground">{profile.bio}</p>
+        )}
+
+        {/* Joined date */}
+        <p className="mt-2 font-mono text-xs text-muted-foreground">
+          Joined{' '}
+          {new Date(profile.created_at).toLocaleDateString('en-US', {
+            month: 'long',
+            year: 'numeric',
+          })}
+        </p>
+
+        {/* Social links */}
+        <div className="mt-3">
+          <SocialLinks profile={profile} />
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -32,7 +32,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 4,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Tooltip as TooltipPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };


### PR DESCRIPTION
- Left-aligned layout with avatar overlapping banner
- Added pencil icon overlay on avatar with tooltip for edit profile
- Moved stats (builds/upvotes) to top-right of card
- Added TooltipProvider to root layout
- Added shadcn tooltip component